### PR TITLE
Fix queued message UUID fallback

### DIFF
--- a/packages/ui/src/components/input-message.tsx
+++ b/packages/ui/src/components/input-message.tsx
@@ -32,6 +32,18 @@ const useIsoLayoutEffect =
 
 const DEFAULT_ACCEPT = "image/png,image/jpeg,application/pdf";
 
+function getUuid() {
+  try {
+    const randomUuid = globalThis.crypto?.randomUUID;
+    if (typeof randomUuid === "function") {
+      return randomUuid.call(globalThis.crypto);
+    }
+  } catch {
+    // Fall back below for older or non-secure browser contexts.
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 interface InputMessageSlotContext {
   /** Opens the native file picker via the hidden `<input type="file">`.
    *  Pass `acceptOverride` (e.g. `"image/*"`) to scope the picker to a
@@ -383,7 +395,7 @@ const InputMessage = forwardRef<HTMLDivElement, InputMessageProps>(
       // then clear the composer and keep focus.
       if (streaming && supportsQueue) {
         const item: QueuedMessage = {
-          id: crypto.randomUUID(),
+          id: getUuid(),
           text: trimmed,
           files: filesArr,
         };


### PR DESCRIPTION
## Summary
- Replace direct crypto.randomUUID() usage in InputMessage queueing with a safe module-local fallback helper.
- Verified tooltip hardening is already present on main from PR #16, so no additional tooltip change was needed.

## Validation
- pnpm --filter @avenire/ui check-types
- pnpm --filter @avenire/web check-types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message queue compatibility with older browsers and non-secure browser contexts through enhanced identifier generation logic that works when standard methods are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->