### PR TITLE
Fix mobile chat composer dock overlap

### DIFF
--- a/apps/web/src/components/chat/chat.tsx
+++ b/apps/web/src/components/chat/chat.tsx
@@ -50,6 +50,7 @@ const EMPTY_COMPOSER_SHELL_CLASSNAME =
   "mx-auto mb-3 w-full max-w-3xl px-4 md:mb-3 md:px-0";
 const FLOATING_COMPOSER_SHELL_CLASSNAME =
   "mx-auto w-full px-3 pb-[calc(0.6rem+env(safe-area-inset-bottom))] md:max-w-3xl md:px-0 md:pb-3";
+const MOBILE_CHAT_COMPOSER_CLOSE_EVENT = "avenire:mobile-chat-composer-close";
 const MOBILE_CHAT_COMPOSER_OPEN_EVENT = "avenire:mobile-chat-composer-open";
 const MOBILE_CHAT_COMPOSER_STATE_EVENT = "avenire:mobile-chat-composer-state";
 const MOBILE_CHAT_VOICE_START_EVENT = "avenire:mobile-chat-voice-start";
@@ -539,10 +540,23 @@ export function Chat({
         }
       });
     };
+    const closeComposer = () => {
+      setMobileComposerOpen(false);
+      window.dispatchEvent(
+        new CustomEvent(MOBILE_CHAT_COMPOSER_STATE_EVENT, {
+          detail: { open: false },
+        })
+      );
+    };
 
     window.addEventListener(MOBILE_CHAT_COMPOSER_OPEN_EVENT, openComposer);
+    window.addEventListener(MOBILE_CHAT_COMPOSER_CLOSE_EVENT, closeComposer);
     return () => {
       window.removeEventListener(MOBILE_CHAT_COMPOSER_OPEN_EVENT, openComposer);
+      window.removeEventListener(
+        MOBILE_CHAT_COMPOSER_CLOSE_EVENT,
+        closeComposer
+      );
     };
   }, []);
 

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -1014,7 +1014,7 @@ function PureMultimodalInput({
     >
       <div
         className={cn(
-          "relative flex w-full grow flex-col overflow-visible rounded-xl p-2 transition-colors duration-100 focus-within:ring-1 focus-within:ring-ring",
+          "relative flex w-full grow flex-col overflow-visible rounded-full p-2 transition-colors duration-100 focus-within:ring-1 focus-within:ring-ring",
           surfaceClasses(2, 2)
         )}
       >

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -10,6 +10,7 @@ import {
   CommandList,
 } from "@avenire/ui/components/command";
 import { Textarea } from "@avenire/ui/components/textarea";
+import { springs } from "@avenire/ui/lib/springs";
 import { surfaceClasses } from "@avenire/ui/lib/surface-classes";
 import {
   ArrowUpIcon,
@@ -486,6 +487,13 @@ function PureMultimodalInput({
     onTranscript: insertTranscript,
     workspaceUuid: effectiveWorkspaceUuid,
   });
+  const composerPlaceholder = isRecording
+    ? "Listening..."
+    : isTranscribing
+      ? "Transcribing..."
+      : isMobile
+        ? "What to learn?"
+        : "What do you want to learn?";
 
   useEffect(() => {
     latestInputRef.current = input;
@@ -1006,8 +1014,7 @@ function PureMultimodalInput({
     >
       <div
         className={cn(
-          "relative flex w-full grow flex-col overflow-visible rounded-xl p-2 transition-[box-shadow,color] duration-100",
-          "focus-within:shadow-[0_0_0_1px_color-mix(in_oklab,var(--foreground)_20%,transparent),0_1px_1px_-0.5px_var(--shadow-color)]",
+          "relative flex w-full grow flex-col overflow-visible rounded-xl p-2 transition-colors duration-100 focus-within:ring-1 focus-within:ring-ring",
           surfaceClasses(2, 2)
         )}
       >
@@ -1028,12 +1035,12 @@ function PureMultimodalInput({
                 className="overflow-hidden pb-1"
                 exit={{ height: 0, opacity: 0, y: -8 }}
                 initial={{ height: 0, opacity: 0, y: -8 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
+                transition={{ ...springs.moderate, bounce: 0 }}
               >
                 <motion.div
                   className="flex flex-wrap items-center gap-2"
                   layout
-                  transition={{ duration: 0.2, ease: "easeOut" }}
+                  transition={{ ...springs.fast, bounce: 0 }}
                 >
                   <AnimatePresence initial={false}>
                     {attachments.map((attachment) => (
@@ -1123,7 +1130,7 @@ function PureMultimodalInput({
 
               <div
                 className={cn(
-                  "flex min-w-0 flex-1",
+                  "flex min-w-0 flex-1 overflow-hidden",
                   centered ? "items-center" : "items-end"
                 )}
               >
@@ -1178,13 +1185,7 @@ function PureMultimodalInput({
                   onSelect={() => {
                     updateTextareaSelection();
                   }}
-                  placeholder={
-                    isRecording
-                      ? "Listening..."
-                      : isTranscribing
-                        ? "Transcribing..."
-                        : "What do you want to learn?"
-                  }
+                  placeholder={composerPlaceholder}
                   ref={textareaRef}
                   rows={1}
                   value={input}
@@ -1249,7 +1250,7 @@ function PureAttachmentsButton({
   return (
     <Button
       aria-label="Add attachment"
-      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       data-testid="attachments-button"
       disabled={status === "submitted" || status === "streaming"}
       onClick={(event) => {
@@ -1293,7 +1294,7 @@ function PureComposerVoiceButton({
               }
         }
         className={cn(
-          "pointer-events-none absolute inset-0 rounded-lg",
+          "pointer-events-none absolute inset-0 rounded-full",
           isRecording ? "bg-red-500/30" : "bg-foreground/10"
         )}
         transition={
@@ -1309,7 +1310,7 @@ function PureComposerVoiceButton({
       <Button
         aria-label={isRecording ? "Stop recording" : "Start voice input"}
         className={cn(
-          "relative flex h-9 w-9 items-center justify-center rounded-lg border border-transparent bg-transparent p-0 text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground",
+          "relative flex h-9 w-9 items-center justify-center rounded-full border border-transparent bg-transparent p-0 text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground",
           (isRecording || isTranscribing) && "text-foreground",
           isRecording &&
             "border-red-500/30 text-red-600 dark:border-red-400/35 dark:text-red-300"
@@ -1372,7 +1373,7 @@ function PureComposerTurboButton({
       aria-label={enabled ? "Disable Apex Turbo" : "Enable Apex Turbo"}
       aria-pressed={enabled}
       className={cn(
-        "flex h-9 w-9 items-center justify-center rounded-lg border border-transparent bg-transparent p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
+        "flex h-9 w-9 items-center justify-center rounded-full border border-transparent bg-transparent p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
         enabled && "text-yellow-700 dark:text-yellow-300",
         disabled && "opacity-60"
       )}
@@ -1420,19 +1421,19 @@ function PureComposerActionButton({
         scale: 1,
       }}
       className="relative h-9 w-9 shrink-0"
-      transition={{ stiffness: 520, damping: 32, mass: 0.7, type: "spring" }}
+      transition={springs.fast}
     >
       <motion.span
         animate={{
           opacity: disabled ? 0.68 : 1,
         }}
-        className="absolute inset-0 rounded-lg bg-primary"
-        transition={{ duration: 0.18, ease: "easeOut" }}
+        className="absolute inset-0 rounded-full bg-primary"
+        transition={springs.fast}
       />
       <Button
         aria-label={isRunning ? "Stop generating" : "Send message"}
         className={cn(
-          "absolute inset-0 flex h-9 w-9 items-center justify-center rounded-lg bg-transparent p-0 text-primary-foreground transition duration-150 ease-out hover:bg-transparent hover:text-primary-foreground focus-visible:ring-0",
+          "absolute inset-0 flex h-9 w-9 items-center justify-center rounded-full bg-transparent p-0 text-primary-foreground transition duration-150 ease-out hover:bg-transparent hover:text-primary-foreground focus-visible:ring-0",
           disabled && "opacity-55"
         )}
         data-testid={isRunning ? "stop-button" : "send-button"}
@@ -1458,7 +1459,7 @@ function PureComposerActionButton({
               exit={{ opacity: 0, rotate: -16, scale: 0.72 }}
               initial={{ opacity: 0, rotate: 16, scale: 0.72 }}
               key="stop"
-              transition={{ duration: 0.18, ease: "easeOut" }}
+              transition={springs.fast}
             >
               <Square className="size-[13px] fill-current" weight="fill" />
             </motion.span>
@@ -1468,7 +1469,7 @@ function PureComposerActionButton({
               exit={{ opacity: 0, rotate: 16, scale: 0.72 }}
               initial={{ opacity: 0, rotate: -16, scale: 0.72 }}
               key="send"
-              transition={{ duration: 0.18, ease: "easeOut" }}
+              transition={springs.fast}
             >
               <ArrowUpIcon className="size-[18px]" weight="bold" />
             </motion.span>

--- a/apps/web/src/components/chat/preview-attachment.tsx
+++ b/apps/web/src/components/chat/preview-attachment.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@avenire/ui/components/button";
-import { FileThumbnail } from "@avenire/ui/components/file-thumbnail";
 import {
   Drawer,
   DrawerContent,
@@ -15,6 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@avenire/ui/components/tooltip";
+import { springs } from "@avenire/ui/lib/springs";
 import {
   FileMediaPlayer,
   type MediaPlaybackSource,
@@ -23,7 +23,6 @@ import {
 import {
   File,
   FileCode as FileCode2,
-  FileText,
   SpinnerGap as LoaderIcon,
   MagnifyingGlassMinus,
   MagnifyingGlassPlus,
@@ -491,93 +490,6 @@ const isCodeLike = (contentType?: string, name?: string) => {
   return Boolean(extension && CODE_EXTENSIONS.includes(extension));
 };
 
-const isMarkdownLike = (contentType?: string, name?: string) =>
-  contentType === "text/markdown" ||
-  name?.split(".").pop()?.toLowerCase() === "md" ||
-  name?.split(".").pop()?.toLowerCase() === "mdx";
-
-interface MarkdownOutlineItem {
-  id: string;
-  level: number;
-  text: string;
-}
-
-function getMarkdownOutline(markdown: string): MarkdownOutlineItem[] {
-  const outline: MarkdownOutlineItem[] = [];
-  const lines = markdown.split(/\r?\n/);
-  let inFence = false;
-
-  for (const line of lines) {
-    if (/^\s*(```|~~~)/.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) {
-      continue;
-    }
-
-    const atx = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
-    if (atx) {
-      outline.push({
-        id: `${outline.length}-${atx[2]}`,
-        level: atx[1].length,
-        text: atx[2].trim(),
-      });
-      continue;
-    }
-
-    const listItem = /^\s{0,3}(?:[-*+]|\d+\.)\s+(.+)$/.exec(line);
-    if (listItem && outline.length < 8) {
-      outline.push({
-        id: `${outline.length}-${listItem[1]}`,
-        level: 4,
-        text: listItem[1].trim(),
-      });
-    }
-  }
-
-  return outline.slice(0, 8);
-}
-
-function MarkdownOutlinePreview({
-  markdown,
-  compact = false,
-}: {
-  markdown: string;
-  compact?: boolean;
-}) {
-  const outline = getMarkdownOutline(markdown);
-
-  if (outline.length === 0) {
-    return (
-      <pre className="max-h-64 whitespace-pre-wrap rounded-md bg-muted p-3 font-mono text-xs">
-        {markdown.substring(0, compact ? 220 : 1200)}
-        {markdown.length > (compact ? 220 : 1200) ? "..." : ""}
-      </pre>
-    );
-  }
-
-  return (
-    <div className="min-w-0 rounded-md border border-border bg-background p-3">
-      <div className="mb-2 flex items-center gap-1.5 text-muted-foreground text-xs">
-        <FileText className="size-3.5" />
-        <span>Document outline</span>
-      </div>
-      <ol className="space-y-1.5">
-        {outline.map((item) => (
-          <li
-            className="truncate text-foreground text-xs"
-            key={item.id}
-            style={{ paddingLeft: Math.max(0, item.level - 1) * 10 }}
-          >
-            {item.text}
-          </li>
-        ))}
-      </ol>
-    </div>
-  );
-}
-
 const playbackDescriptorCache = new Map<
   string,
   MediaPlaybackDescriptor | Promise<MediaPlaybackDescriptor | null> | null
@@ -863,39 +775,32 @@ export function PreviewAttachment({
     }
   };
 
-  const renderLoadingOverlay = () =>
-    status === "uploading" || status === "pending" ? (
-      <div className="absolute inset-0 flex items-center justify-center bg-background/55">
-        <LoaderIcon className="h-4 w-4 animate-spin text-muted-foreground" />
-      </div>
-    ) : null;
-
-  const renderThumbnail = (size = 48) => {
-    if (file) {
-      return (
-        <div className="relative shrink-0">
-          <FileThumbnail file={file} size={size} />
-          {renderLoadingOverlay()}
-        </div>
-      );
-    }
-
-    const squareStyle = { height: size, width: size };
+  const renderThumbnail = (size: "default" | "composer" = "default") => {
+    const thumbnailClassName =
+      size === "composer" ? "h-20 w-20 rounded-lg" : "h-12 w-12 rounded-md";
+    const imageSize = size === "composer" ? 80 : 48;
+    const iconClassName = size === "composer" ? "h-8 w-8" : "h-6 w-6";
 
     if (contentType?.startsWith("image") && url) {
       return (
         <div
-          className="relative shrink-0 overflow-hidden rounded-lg border border-border bg-accent"
-          style={squareStyle}
+          className={cn(
+            "relative shrink-0 overflow-hidden bg-muted",
+            thumbnailClassName
+          )}
         >
           <img
             alt={name ?? "An image attachment"}
             className="h-full w-full object-cover"
-            height={size}
+            height={imageSize}
             src={url}
-            width={size}
+            width={imageSize}
           />
-          {renderLoadingOverlay()}
+          {(status === "uploading" || status === "pending") && (
+            <div className="absolute inset-0 flex items-center justify-center bg-background/60">
+              <LoaderIcon className="h-4 w-4 animate-spin text-foreground" />
+            </div>
+          )}
         </div>
       );
     }
@@ -903,21 +808,27 @@ export function PreviewAttachment({
     if (contentType?.startsWith("video") && url) {
       return (
         <div
-          className="relative shrink-0 overflow-hidden rounded-lg border border-border bg-accent"
-          style={squareStyle}
+          className={cn(
+            "relative shrink-0 overflow-hidden bg-muted",
+            thumbnailClassName
+          )}
         >
           {playbackDescriptor?.posterUrl ? (
             <img
               alt={name ?? "A video attachment"}
               className="h-full w-full object-cover"
-              height={size}
+              height={imageSize}
               src={playbackDescriptor.posterUrl}
-              width={size}
+              width={imageSize}
             />
           ) : (
             <video className="h-full w-full object-cover" muted src={url} />
           )}
-          {renderLoadingOverlay()}
+          {(status === "uploading" || status === "pending") && (
+            <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/60">
+              <LoaderIcon className="h-4 w-4 animate-spin text-foreground" />
+            </div>
+          )}
         </div>
       );
     }
@@ -925,35 +836,58 @@ export function PreviewAttachment({
     if (contentType === "application/pdf") {
       return (
         <div
-          className="relative flex shrink-0 items-center justify-center rounded-lg border border-border bg-accent font-medium text-[10px] text-muted-foreground"
-          style={squareStyle}
+          className={cn(
+            "relative flex shrink-0 items-center justify-center border border-red-200 bg-red-50 font-semibold text-red-600",
+            thumbnailClassName,
+            size === "composer" ? "text-xs" : "text-[10px]"
+          )}
         >
           PDF
-          {renderLoadingOverlay()}
+          {(status === "uploading" || status === "pending") && (
+            <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/60">
+              <LoaderIcon className="h-4 w-4 animate-spin text-foreground" />
+            </div>
+          )}
         </div>
       );
     }
 
     if (isCodeLike(contentType, name)) {
-      const Icon = isMarkdownLike(contentType, name) ? FileText : FileCode2;
       return (
         <div
-          className="relative flex shrink-0 items-center justify-center rounded-lg border border-border bg-accent text-muted-foreground"
-          style={squareStyle}
+          className={cn(
+            "relative flex shrink-0 items-center justify-center border border-green-200 bg-green-50",
+            thumbnailClassName
+          )}
         >
-          <Icon className="h-5 w-5" />
-          {renderLoadingOverlay()}
+          <FileCode2
+            className={cn(
+              size === "composer" ? "h-7 w-7" : "h-5 w-5",
+              "text-green-700"
+            )}
+          />
+          {(status === "uploading" || status === "pending") && (
+            <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/60">
+              <LoaderIcon className="h-4 w-4 animate-spin text-foreground" />
+            </div>
+          )}
         </div>
       );
     }
 
     return (
       <div
-        className="relative flex shrink-0 items-center justify-center rounded-lg border border-border bg-accent"
-        style={squareStyle}
+        className={cn(
+          "relative flex shrink-0 items-center justify-center border bg-muted",
+          thumbnailClassName
+        )}
       >
-        <File className="h-6 w-6 text-muted-foreground" />
-        {renderLoadingOverlay()}
+        <File className={cn(iconClassName, "text-muted-foreground")} />
+        {(status === "uploading" || status === "pending") && (
+          <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/60">
+            <LoaderIcon className="h-4 w-4 animate-spin text-foreground" />
+          </div>
+        )}
       </div>
     );
   };
@@ -1007,14 +941,6 @@ export function PreviewAttachment({
               <track kind="captions" />
             </video>
           )}
-        </div>
-      );
-    }
-
-    if (isMarkdownLike(contentType, name) && textPreview) {
-      return (
-        <div className="max-w-xs">
-          <MarkdownOutlinePreview compact markdown={textPreview} />
         </div>
       );
     }
@@ -1086,21 +1012,6 @@ export function PreviewAttachment({
       );
     }
 
-    if (isMarkdownLike(contentType, name) && status === "completed") {
-      return (
-        <div className="max-h-[70vh] overflow-auto p-4">
-          {isLoadingText ? (
-            <p className="inline-flex items-center gap-2 text-muted-foreground text-sm">
-              <Spinner className="size-4" />
-              Loading preview...
-            </p>
-          ) : (
-            <MarkdownOutlinePreview markdown={textPreview ?? ""} />
-          )}
-        </div>
-      );
-    }
-
     if (isCodeLike(contentType, name) && status === "completed") {
       return (
         <div className="max-h-[70vh] overflow-auto">
@@ -1152,10 +1063,10 @@ export function PreviewAttachment({
         <motion.div
           animate={{ opacity: 1, scale: 1 }}
           className="group relative shrink-0 cursor-default"
-          exit={{ opacity: 0, scale: 0.92 }}
-          initial={{ opacity: 0, scale: 0.92 }}
+          exit={{ opacity: 0, scale: 0.9, transition: { duration: 0.06 } }}
+          initial={{ opacity: 0, scale: 0.9 }}
           layout
-          transition={{ duration: 0.18, ease: "easeOut" }}
+          transition={springs.fast}
         >
           <Tooltip>
             <TooltipTrigger
@@ -1163,7 +1074,7 @@ export function PreviewAttachment({
                 <Button
                   aria-label={name ?? "Attachment"}
                   className={cn(
-                    "relative h-20 w-20 overflow-hidden rounded-lg border-0 bg-transparent p-0 shadow-none hover:bg-transparent"
+                    "relative h-20 w-20 overflow-hidden rounded-lg border border-border/80 bg-background p-0 text-left transition-colors hover:bg-muted"
                   )}
                   onBlur={() => setIsHovered(false)}
                   onClick={() => {
@@ -1183,12 +1094,11 @@ export function PreviewAttachment({
                 />
               }
             >
-              {renderThumbnail(80)}
+              {renderThumbnail("composer")}
 
               {onRemove && id ? (
                 <Button
-                  aria-label={`Remove ${name ?? "attachment"}`}
-                  className="absolute top-1 right-1 z-10 h-5 w-5 rounded-full bg-neutral-900 text-white opacity-0 transition-opacity duration-100 hover:bg-neutral-800 hover:text-white group-hover:opacity-100 focus-visible:opacity-100"
+                  className="absolute top-1 right-1 z-10 h-5 w-5 rounded-full bg-foreground text-background opacity-0 transition-opacity group-hover:opacity-100 hover:bg-foreground hover:text-background focus-visible:opacity-100"
                   onClick={(event) => {
                     event.stopPropagation();
                     onRemove(id);
@@ -1197,7 +1107,7 @@ export function PreviewAttachment({
                   type="button"
                   variant="ghost"
                 >
-                  <X className="h-3 w-3" weight="bold" />
+                  <X className="h-3 w-3" />
                 </Button>
               ) : null}
             </TooltipTrigger>

--- a/apps/web/src/components/chat/preview-attachment.tsx
+++ b/apps/web/src/components/chat/preview-attachment.tsx
@@ -780,8 +780,9 @@ export function PreviewAttachment({
       size === "composer" ? "h-20 w-20 rounded-lg" : "h-12 w-12 rounded-md";
     const imageSize = size === "composer" ? 80 : 48;
     const iconClassName = size === "composer" ? "h-8 w-8" : "h-6 w-6";
+    const thumbnailPreviewUrl = previewUrl || url;
 
-    if (contentType?.startsWith("image") && url) {
+    if (contentType?.startsWith("image") && thumbnailPreviewUrl) {
       return (
         <div
           className={cn(
@@ -793,7 +794,7 @@ export function PreviewAttachment({
             alt={name ?? "An image attachment"}
             className="h-full w-full object-cover"
             height={imageSize}
-            src={url}
+            src={thumbnailPreviewUrl}
             width={imageSize}
           />
           {(status === "uploading" || status === "pending") && (
@@ -805,7 +806,7 @@ export function PreviewAttachment({
       );
     }
 
-    if (contentType?.startsWith("video") && url) {
+    if (contentType?.startsWith("video") && thumbnailPreviewUrl) {
       return (
         <div
           className={cn(
@@ -822,7 +823,11 @@ export function PreviewAttachment({
               width={imageSize}
             />
           ) : (
-            <video className="h-full w-full object-cover" muted src={url} />
+            <video
+              className="h-full w-full object-cover"
+              muted
+              src={thumbnailPreviewUrl}
+            />
           )}
           {(status === "uploading" || status === "pending") && (
             <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/60">

--- a/apps/web/src/components/dashboard/mobile-workspace-dock.tsx
+++ b/apps/web/src/components/dashboard/mobile-workspace-dock.tsx
@@ -33,6 +33,7 @@ import { useDashboardOverlayStore } from "@/stores/dashboardOverlayStore";
 import { quickCaptureActions } from "@/stores/quickCaptureStore";
 
 const MOBILE_CHAT_COMPOSER_OPEN_EVENT = "avenire:mobile-chat-composer-open";
+const MOBILE_CHAT_COMPOSER_CLOSE_EVENT = "avenire:mobile-chat-composer-close";
 const MOBILE_CHAT_COMPOSER_STATE_EVENT = "avenire:mobile-chat-composer-state";
 
 interface MobileChatSummary {
@@ -173,20 +174,25 @@ export function MobileWorkspaceDock({
       const detail = (event as CustomEvent<{ open?: boolean }>).detail;
       setComposerOpen(Boolean(detail?.open));
     };
+    const handleClose = () => {
+      setComposerOpen(false);
+    };
 
     window.addEventListener(MOBILE_CHAT_COMPOSER_STATE_EVENT, handleState);
+    window.addEventListener(MOBILE_CHAT_COMPOSER_CLOSE_EVENT, handleClose);
     return () => {
       window.removeEventListener(MOBILE_CHAT_COMPOSER_STATE_EVENT, handleState);
+      window.removeEventListener(MOBILE_CHAT_COMPOSER_CLOSE_EVENT, handleClose);
     };
   }, []);
 
   useEffect(() => {
-    setComposerOpen(false);
+    window.dispatchEvent(new CustomEvent(MOBILE_CHAT_COMPOSER_CLOSE_EVENT));
   }, [pathname]);
 
   useEffect(() => {
     const closeComposerState = () => {
-      setComposerOpen(false);
+      window.dispatchEvent(new CustomEvent(MOBILE_CHAT_COMPOSER_CLOSE_EVENT));
     };
 
     window.addEventListener("popstate", closeComposerState);

--- a/apps/web/src/components/dashboard/mobile-workspace-dock.tsx
+++ b/apps/web/src/components/dashboard/mobile-workspace-dock.tsx
@@ -181,6 +181,30 @@ export function MobileWorkspaceDock({
   }, []);
 
   useEffect(() => {
+    setComposerOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    const closeComposerState = () => {
+      setComposerOpen(false);
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        closeComposerState();
+      }
+    };
+
+    window.addEventListener("pageshow", closeComposerState);
+    window.addEventListener("popstate", closeComposerState);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("pageshow", closeComposerState);
+      window.removeEventListener("popstate", closeComposerState);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!(sheetOpen && pathname.startsWith("/workspace/flashcards"))) {
       return;
     }

--- a/apps/web/src/components/dashboard/mobile-workspace-dock.tsx
+++ b/apps/web/src/components/dashboard/mobile-workspace-dock.tsx
@@ -188,19 +188,10 @@ export function MobileWorkspaceDock({
     const closeComposerState = () => {
       setComposerOpen(false);
     };
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        closeComposerState();
-      }
-    };
 
-    window.addEventListener("pageshow", closeComposerState);
     window.addEventListener("popstate", closeComposerState);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      window.removeEventListener("pageshow", closeComposerState);
       window.removeEventListener("popstate", closeComposerState);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, []);
 

--- a/apps/web/src/components/dashboard/shell.tsx
+++ b/apps/web/src/components/dashboard/shell.tsx
@@ -224,7 +224,7 @@ export function DashboardLayout({
         />
       ) : null}
       <SidebarInset className="relative h-full min-h-0 overflow-hidden bg-background md:peer-data-[variant=inset]:mb-0">
-        <div className="flex h-full min-h-0 flex-1 overflow-hidden">
+        <div className="absolute inset-0 flex min-h-0 overflow-hidden">
           <WorkspacePaneRenderer />
         </div>
         {deferredReady ? (

--- a/apps/web/src/components/dashboard/workspace-pane-renderer.tsx
+++ b/apps/web/src/components/dashboard/workspace-pane-renderer.tsx
@@ -435,7 +435,7 @@ export function WorkspacePaneRenderer() {
         paneId={mobilePaneId}
         route={browserRoute}
       >
-        <div className="flex h-full w-full flex-col bg-background">
+        <div className="flex h-full min-h-0 w-full flex-col bg-background">
           <WorkspaceHeader
             className="border-border/60 border-b"
             compact

--- a/apps/web/src/components/flashcards/dashboard.tsx
+++ b/apps/web/src/components/flashcards/dashboard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Badge } from "@avenire/ui/components/badge";
 import { Button } from "@avenire/ui/components/button";
 import {
   Dialog,
@@ -12,6 +11,10 @@ import {
   DialogTrigger,
 } from "@avenire/ui/components/dialog";
 import {
+  Drawer,
+  DrawerContent,
+} from "@avenire/ui/components/drawer";
+import {
   Empty,
   EmptyContent,
   EmptyDescription,
@@ -21,29 +24,32 @@ import {
 } from "@avenire/ui/components/empty";
 import { Input } from "@avenire/ui/components/input";
 import { Label } from "@avenire/ui/components/label";
-import { ScrollArea } from "@avenire/ui/components/scroll-area";
 import { Textarea } from "@avenire/ui/components/textarea";
 import { cn } from "@avenire/ui/lib/utils";
 import {
   BookOpenText as BookOpenCheck,
-  ChatText as MessageSquareText,
+  CaretLeft,
+  CaretRight,
   Plus,
+  WarningCircle,
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
 import type { Route } from "next";
+import Image from "next/image";
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
+import { Markdown } from "@/components/chat/markdown";
 import {
   HeaderActions,
   HeaderBreadcrumbs,
   HeaderLeadingIcon,
 } from "@/components/dashboard/header-portal";
-import { StabilityCurves } from "@/components/flashcards/stability-curves";
 import { prefetchFlashcardSet } from "@/lib/flashcard-browser-cache";
 import type { FlashcardDashboardRecord } from "@/lib/flashcards";
 import type { MisconceptionRecord } from "@/lib/learning-data";
+import { STATIC_ASSETS } from "@/lib/static-assets";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
-  useCurrentWorkspacePaneCompact,
   usePanePathname,
   usePaneRouter,
   usePaneSearchParams,
@@ -103,18 +109,128 @@ async function generateOnboardingSet(
   return setId;
 }
 
-function getEnrollmentLabel(
-  status: FlashcardDashboardRecord["sets"][number]["enrollmentStatus"]
-) {
-  if (status === "active") {
-    return "Study active";
+function formatShortDate(value: string | null | undefined) {
+  if (!value) {
+    return null;
   }
 
-  if (status === "paused") {
-    return "Paused";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
   }
 
-  return "Not enrolled";
+  return date.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+function getMisconceptionSummary(misconception: MisconceptionRecord) {
+  return misconception.blocks?.summary ?? misconception.reason;
+}
+
+function getCorrectedMentalModel(misconception: MisconceptionRecord) {
+  return (
+    misconception.blocks?.correctedMentalModel ??
+    "Open this with AI to build the corrected model from the flagged evidence."
+  );
+}
+
+function DashboardMarkdownPreview({
+  className,
+  content,
+  id,
+}: {
+  className?: string;
+  content: string;
+  id: string;
+}) {
+  return (
+    <Markdown
+      className={cn(
+        "max-w-none text-inherit leading-[1.45] [&_*]:my-0 [&_code:not(pre_code)]:rounded-md [&_code:not(pre_code)]:bg-muted [&_code:not(pre_code)]:px-1 [&_li]:my-0 [&_ol]:my-0 [&_ol]:pl-4 [&_p]:my-0 [&_pre]:hidden [&_ul]:my-0 [&_ul]:pl-4",
+        className
+      )}
+      content={content}
+      id={id}
+      parseIncompleteMarkdown={false}
+    />
+  );
+}
+
+function ExpandableText({ children }: { children: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div>
+      <p
+        className={cn(
+          "mt-1 text-muted-foreground text-sm leading-6",
+          !expanded && "line-clamp-2"
+        )}
+      >
+        {children}
+      </p>
+      <button
+        className="mt-1 font-medium text-foreground text-xs transition-colors hover:text-muted-foreground"
+        onClick={() => setExpanded((value) => !value)}
+        type="button"
+      >
+        {expanded ? "Show less" : "Read more"}
+      </button>
+    </div>
+  );
+}
+
+function StrideFileIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 116.4 162.9"
+    >
+      <path
+        className="fill-muted-foreground/70"
+        d="m9.5 23.8v115.2c0.1 7.4 6.2 15 15.5 15h68c4.3 0 8.1 0.3 11.6-1.3 0.2-1.6 3-7.6 3-13.7v-92.2c0-4.9-2.7-11.5-7-14.8l-22.6-18.9c-3-2.4-7.6-4.3-12.6-4.3h-40.4c-8.3 0-15.5 6-15.5 15z"
+      />
+      <path
+        className="fill-muted-foreground/75"
+        d="m9.5 24v115.7c0 7.6 6.5 14.3 15.6 14.3h68c8.5 0 14.4-6.5 14.4-15l-0.1-92.6c0.2-4.9-2.5-11.1-6.8-14.4l-22.6-18.9c-3-2.4-7.6-4.3-12.6-4.3h-40.4c-8.3 0-15.5 6.2-15.5 15.2z"
+      />
+      <path
+        className="fill-muted-foreground/55"
+        d="m66.5 8.8c10.6 0.7 17.4 8.6 17.4 18.5 0 3-0.6 8.8 3.1 8.2 2.3-0.2 3.4-1.4 6.8-1.4 8.4-0.1 13.7 5.2 13.8 12.2-0.3-6.3-2.5-12.3-6.3-15l-22.6-17.8c-3.5-2.8-8.1-4.5-12.2-4.7z"
+      />
+      <path
+        className="fill-background/50"
+        d="m57.5 44.6h-34.7c-2.2 0-4.2-1.6-4.2-4 0-2.1 1.8-4.1 4.2-4.1h34.7c2.2 0 3.9 1.8 3.9 4.1s-1.8 4-3.9 4z"
+      />
+      <path
+        className="fill-background/50"
+        d="m93.6 81.8h-70.9c-2.2 0.3-4.1-1.5-4.1-3.9 0-2.2 2-4.3 4.2-4.3h70.8c2.5 0 4.4 1.6 4.4 4.1 0 2.2-1.9 4.1-4.4 4.1z"
+      />
+      <path
+        className="fill-background/50"
+        d="m93.5 102.5h-70.8c-2.2 0.2-4.1-1.6-4.1-4 0-2.1 2-4.2 4.2-4.2h70.7c2.4 0 4.5 1.7 4.5 4.2 0 2.2-2.1 4-4.5 4z"
+      />
+      <path
+        className="fill-background/50"
+        d="m93.6 69.7h-70.8c-2.2 0.2-4.2-1.6-4.2-4.1 0-2.1 1.8-4.5 4.2-4.5h70.8c2.3 0 4.4 1.8 4.4 4.4 0 2.2-2.1 4.2-4.4 4.2z"
+      />
+      <path
+        className="fill-background/50"
+        d="m93.5 57h-70.8c-2.2 0.3-4.1-1.5-4.1-4.1 0-2.2 2-4.9 4.2-4.9h70.7c2.4 0 4.5 2.4 4.5 4.3 0 2.6-2.1 4.7-4.5 4.7z"
+      />
+      <path
+        className="fill-background/50"
+        d="m93.5 115.4h-70.8c-2.2 0.2-4.1-1.5-4.1-4.1 0-2.3 1.8-5 4.2-5h70.7c2.4 0 4.5 1.8 4.5 4.5 0 2.2-2.1 4.6-4.5 4.6z"
+      />
+      <path
+        className="fill-background/50"
+        d="m93.5 127.6h-70.8c-2.2 0.3-4.1-1.5-4.1-4 0-2.1 1.8-4.3 4.1-4.3h70.8c2.4 0 4.5 1.7 4.5 4.3 0 2.3-2.1 4-4.5 4z"
+      />
+    </svg>
+  );
 }
 
 export function FlashcardsDashboard({
@@ -125,9 +241,9 @@ export function FlashcardsDashboard({
   initialDashboard: FlashcardDashboardRecord;
 }) {
   const router = usePaneRouter();
+  const isMobile = useIsMobile();
   const pathname = usePanePathname();
   const searchParams = usePaneSearchParams();
-  const isMobile = useCurrentWorkspacePaneCompact();
   const { recordRoute } = usePaneWorkspaceHistoryActions();
   const [dashboard] = useState(initialDashboard);
   const [createOpen, setCreateOpen] = useState(false);
@@ -172,33 +288,65 @@ export function FlashcardsDashboard({
       orderedSets.find((set) => set.dueCount > 0 || set.newCount > 0) ?? null,
     [orderedSets]
   );
-  const [selectedSetId, setSelectedSetId] = useState<string | null>(
-    reviewTarget?.id ?? orderedSets[0]?.id ?? null
-  );
-
-  useEffect(() => {
-    if (
-      selectedSetId &&
-      orderedSets.some((candidate) => candidate.id === selectedSetId)
-    ) {
-      return;
-    }
-
-    setSelectedSetId(reviewTarget?.id ?? orderedSets[0]?.id ?? null);
-  }, [orderedSets, reviewTarget, selectedSetId]);
-
-  const selectedSet = useMemo(
-    () =>
-      orderedSets.find((candidate) => candidate.id === selectedSetId) ?? null,
-    [orderedSets, selectedSetId]
-  );
-  const selectedSnapshots = useMemo(
-    () =>
-      dashboard.cardSnapshots.filter(
-        (snapshot) => snapshot.card.setId === selectedSetId
+  const activeMisconceptions = overviewQuery.data?.activeMisconceptions ?? [];
+  const dashboardTotals = useMemo(
+    () => ({
+      cards: orderedSets.reduce((total, set) => total + set.cardCount, 0),
+      due: orderedSets.reduce(
+        (total, set) => total + set.dueCount + set.newCount,
+        0
       ),
-    [dashboard.cardSnapshots, selectedSetId]
+      reviewsToday: orderedSets.reduce(
+        (total, set) => total + set.reviewCountToday,
+        0
+      ),
+    }),
+    [orderedSets]
   );
+  const weeklyPlanSets = useMemo(() => orderedSets.slice(0, 4), [orderedSets]);
+  const knowledgeGaps = useMemo(
+    () =>
+      activeMisconceptions
+        .slice()
+        .sort((left, right) => right.confidence - left.confidence)
+        .slice(0, 3),
+    [activeMisconceptions]
+  );
+  const selectedMisconceptionIndex = selectedMisconception
+    ? activeMisconceptions.findIndex(
+        (misconception) => misconception.id === selectedMisconception.id
+      )
+    : -1;
+  const reviewedSnapshots = dashboard.cardSnapshots.filter((snapshot) =>
+    ["learning", "young", "mature", "relearning"].includes(
+      snapshot.displayState
+    )
+  );
+  const retainedSnapshots = reviewedSnapshots.filter((snapshot) =>
+    ["young", "mature"].includes(snapshot.displayState)
+  );
+  const masteredConcepts = retainedSnapshots.length;
+  const currentlyLearning =
+    dashboardTotals.due +
+    dashboard.cardSnapshots.filter((snapshot) =>
+      ["learning", "relearning", "new"].includes(snapshot.displayState)
+    ).length;
+  const retentionPercent =
+    reviewedSnapshots.length > 0
+      ? Math.round((retainedSnapshots.length / reviewedSnapshots.length) * 100)
+      : 0;
+  const masteredPercent =
+    reviewedSnapshots.length > 0
+      ? Math.round((masteredConcepts / reviewedSnapshots.length) * 100)
+      : 0;
+  const learningPercent =
+    dashboardTotals.cards > 0
+      ? Math.round((currentlyLearning / dashboardTotals.cards) * 100)
+      : 0;
+  const gapPressurePercent =
+    activeMisconceptions.length > 0
+      ? Math.min(100, Math.max(12, activeMisconceptions.length * 10))
+      : 0;
   const headerLeadingIcon = useMemo(
     () => <BookOpenCheck className="size-3.5" />,
     []
@@ -362,9 +510,164 @@ export function FlashcardsDashboard({
     }
   };
 
+  const showAdjacentMisconception = (direction: -1 | 1) => {
+    if (activeMisconceptions.length === 0) {
+      return;
+    }
+
+    const currentIndex =
+      selectedMisconceptionIndex >= 0 ? selectedMisconceptionIndex : 0;
+    const nextIndex =
+      (currentIndex + direction + activeMisconceptions.length) %
+      activeMisconceptions.length;
+    setSelectedMisconception(activeMisconceptions[nextIndex] ?? null);
+  };
+
+  const closeSelectedMisconception = () => {
+    setSelectedMisconception(null);
+    if (searchParams.get("misconception")) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("misconception");
+      const query = params.toString();
+      router.replace((query ? `${pathname}?${query}` : pathname) as Route);
+    }
+  };
+
+  const renderMisconceptionPanel = () => {
+    if (!selectedMisconception) {
+      return null;
+    }
+
+    return (
+      <>
+        <div className="relative h-40 w-full shrink-0 overflow-hidden sm:h-48">
+          {activeMisconceptions.length > 1 ? (
+            <div className="absolute top-3 right-3 z-10 flex items-center gap-1">
+              <Button
+                aria-label="Previous knowledge gap"
+                className="h-7 w-7 rounded-md bg-background/80 p-0 text-foreground hover:bg-background"
+                onClick={() => showAdjacentMisconception(-1)}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <CaretLeft className="size-4" />
+              </Button>
+              <Button
+                aria-label="Next knowledge gap"
+                className="h-7 w-7 rounded-md bg-background/80 p-0 text-foreground hover:bg-background"
+                onClick={() => showAdjacentMisconception(1)}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <CaretRight className="size-4" />
+              </Button>
+            </div>
+          ) : null}
+          <Image
+            alt=""
+            className="h-full w-full object-cover"
+            height={192}
+            src={STATIC_ASSETS.banner1}
+            width={720}
+            unoptimized
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="space-y-7 px-6 py-7 sm:px-8">
+            <div>
+              <h2 className="text-balance font-semibold text-3xl text-foreground leading-tight">
+                {selectedMisconception.concept}
+              </h2>
+              <p className="mt-2 text-muted-foreground text-sm">
+                {selectedMisconception.subject} / {selectedMisconception.topic}
+              </p>
+              <p className="mt-5 max-w-2xl text-foreground/80 text-sm leading-6">
+                {getMisconceptionSummary(selectedMisconception)}
+              </p>
+            </div>
+
+            <section>
+              <h3 className="font-semibold text-foreground text-base">
+                What was identified
+              </h3>
+              <div className="mt-4 space-y-4">
+                <div className="flex gap-4">
+                  <WarningCircle className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+                  <div>
+                    <p className="font-medium text-foreground text-sm">
+                      Why this was flagged
+                    </p>
+                    <ExpandableText>
+                      {selectedMisconception.reason}
+                    </ExpandableText>
+                  </div>
+                </div>
+                <div className="flex gap-4">
+                  <BookOpenCheck className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+                  <div>
+                    <p className="font-medium text-foreground text-sm">
+                      Correct mental model
+                    </p>
+                    <ExpandableText>
+                      {getCorrectedMentalModel(selectedMisconception)}
+                    </ExpandableText>
+                  </div>
+                </div>
+                <div className="flex gap-4">
+                  <WarningCircle className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+                  <div>
+                    <p className="font-medium text-foreground text-sm">
+                      Supporting evidence
+                    </p>
+                    <p className="mt-1 text-muted-foreground text-sm leading-6">
+                      {Math.round(selectedMisconception.confidence * 100)}%
+                      confidence · {selectedMisconception.evidenceCount}{" "}
+                      evidence item
+                      {selectedMisconception.evidenceCount === 1 ? "" : "s"}
+                      {" · "}
+                      {formatShortDate(selectedMisconception.lastSeenAt) ??
+                        "recently seen"}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-2 border-border/60 border-t px-6 py-4 sm:flex-row sm:px-8">
+          <Button
+            className="h-9 flex-1 justify-center"
+            onClick={() => {
+              const prompt = promptForMisconception(selectedMisconception);
+              router.push(`/workspace/chats/new?prompt=${prompt}`);
+            }}
+            type="button"
+          >
+            Fix With AI
+          </Button>
+          <Button
+            className="h-9 flex-1 justify-center"
+            onClick={() => {
+              const prompt = promptForFlashcards(selectedMisconception);
+              router.push(`/workspace/chats/new?prompt=${prompt}`);
+            }}
+            type="button"
+            variant="outline"
+          >
+            Review Related Cards
+          </Button>
+        </div>
+      </>
+    );
+  };
+
   return (
     <div className="h-full overflow-y-auto bg-background">
-      <div className="flex w-full flex-col gap-3 px-4 py-4 md:gap-4 md:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-6 md:px-8 lg:px-10">
         <HeaderLeadingIcon>{headerLeadingIcon}</HeaderLeadingIcon>
         <HeaderActions>
           <div className="flex flex-wrap items-center gap-1.5 md:gap-2">
@@ -510,492 +813,253 @@ export function FlashcardsDashboard({
           </div>
         ) : null}
 
-        <motion.div
-          animate={{ opacity: 1, y: 0 }}
-          className="grid gap-4 md:gap-6 xl:grid-cols-[minmax(18rem,0.88fr)_minmax(0,1.12fr)]"
-          initial={{ opacity: 0, y: 8 }}
-          transition={{ duration: 0.22, ease: "easeOut" }}
+        <section className="border-border/60 border-b pb-10 pt-6">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+            <div className="min-w-0">
+              <h1 className="text-balance font-semibold text-3xl text-foreground tracking-tight md:text-4xl">
+                Ready to review
+              </h1>
+              <div className="mt-7 flex flex-wrap gap-12">
+                <div>
+                  <p className="text-muted-foreground text-sm">Cards due</p>
+                  <p className="mt-1 font-semibold text-4xl text-foreground tabular-nums">
+                    {dashboardTotals.due}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground text-sm">
+                    Knowledge gaps
+                  </p>
+                  <p className="mt-1 font-semibold text-4xl text-foreground tabular-nums">
+                    {activeMisconceptions.length}
+                  </p>
+                </div>
+              </div>
+            </div>
+            <Button
+              className="h-9 justify-center rounded-md px-4"
+              disabled={!reviewTarget}
+              onClick={() => {
+                if (!reviewTarget) {
+                  return;
+                }
+                router.push(
+                  `/workspace/flashcards/${reviewTarget.id}?study=1` as Route
+                );
+              }}
+              type="button"
+            >
+              <BookOpenCheck className="size-4" />
+              Start review
+            </Button>
+          </div>
+        </section>
+
+        <section className="space-y-6 border-border/60 border-b pb-10">
+          <h2 className="font-semibold text-foreground text-lg">
+            Performance overview
+          </h2>
+          <div className="grid gap-9 md:grid-cols-2 xl:grid-cols-4">
+            {[
+              {
+                color: "bg-emerald-500",
+                detail: "estimated retained",
+                label: "Retention",
+                progress: retentionPercent,
+                value: `${retentionPercent}%`,
+              },
+              {
+                color: "bg-primary",
+                detail: "stable cards",
+                label: "Mastered concepts",
+                progress: masteredPercent,
+                value: masteredConcepts,
+              },
+              {
+                color: "bg-sky-500",
+                detail: "in active practice",
+                label: "Currently learning",
+                progress: learningPercent,
+                value: currentlyLearning,
+              },
+              {
+                color: "bg-destructive",
+                detail: "need reinforcement",
+                label: "Knowledge gaps",
+                progress: gapPressurePercent,
+                value: activeMisconceptions.length,
+              },
+            ].map((metric) => (
+              <div className="flex min-h-20 gap-4" key={metric.label}>
+                <div className="mt-1 flex h-16 w-1.5 shrink-0 flex-col justify-end overflow-hidden rounded-full bg-secondary">
+                  <div
+                    className={cn("min-h-1 rounded-full", metric.color)}
+                    style={{ height: `${metric.progress}%` }}
+                  />
+                </div>
+                <div>
+                  <p className="text-muted-foreground text-sm">
+                    {metric.label}
+                  </p>
+                  <p className="mt-2 font-semibold text-3xl text-foreground tabular-nums">
+                    {metric.value}
+                  </p>
+                  <p className="mt-1 text-muted-foreground text-xs">
+                    {metric.detail}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section
+          className="space-y-6 border-border/60 border-b pb-10"
+          id="continue-learning"
         >
-          <div className="min-w-0">
-            <h2 className="font-medium text-foreground text-sm">Decks</h2>
-            <p className="mb-2 text-muted-foreground text-xs md:mb-0">
-              Pick a deck and jump into review.
-            </p>
-            {isMobile ? (
-              <div className="space-y-2">
-                {orderedSets.length === 0 ? (
-                  <Empty className="min-h-[10rem]">
-                    <EmptyHeader>
-                      <EmptyMedia variant="icon">
-                        <BookOpenCheck className="size-4" />
-                      </EmptyMedia>
-                      <EmptyTitle>No flashcard sets yet</EmptyTitle>
-                    </EmptyHeader>
-                    <EmptyContent>
-                      <EmptyDescription>
-                        Create a set, or let the AI generate one from a
-                        misconception or study prompt.
-                      </EmptyDescription>
-                    </EmptyContent>
-                  </Empty>
-                ) : (
-                  orderedSets.map((set) => {
-                    const isSelected = set.id === selectedSetId;
-                    return (
-                      <button
-                        className={cn(
-                          "flex w-full cursor-pointer items-start justify-between gap-3 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-secondary md:px-3 md:py-2.5",
-                          isSelected && "bg-secondary/70"
-                        )}
-                        key={set.id}
-                        onClick={() => setSelectedSetId(set.id)}
-                        onFocus={() => {
-                          prefetchFlashcardSet(set.id).catch(() => undefined);
-                        }}
-                        onMouseEnter={() => {
-                          prefetchFlashcardSet(set.id).catch(() => undefined);
-                        }}
-                        type="button"
-                      >
-                        <div className="min-w-0">
-                          <p className="truncate text-foreground text-[13px] md:text-sm">
-                            {set.title}
-                          </p>
-                          <p className="mt-1 text-[11px] text-muted-foreground">
-                            {set.dueCount + set.newCount} ready ·{" "}
-                            {set.cardCount} cards
-                          </p>
-                        </div>
-                        {set.dueCount > 0 ? (
-                          <Badge
-                            className="shrink-0 rounded-md"
-                            variant="outline"
-                          >
-                            {set.dueCount} due
-                          </Badge>
-                        ) : null}
-                      </button>
-                    );
-                  })
-                )}
-              </div>
-            ) : (
-              <ScrollArea className="max-h-[16rem]">
-                <div className="space-y-2 p-1">
-                  {orderedSets.length === 0 ? (
-                    <Empty className="min-h-[10rem]">
-                      <EmptyHeader>
-                        <EmptyMedia variant="icon">
-                          <BookOpenCheck className="size-4" />
-                        </EmptyMedia>
-                        <EmptyTitle>No flashcard sets yet</EmptyTitle>
-                      </EmptyHeader>
-                      <EmptyContent>
-                        <EmptyDescription>
-                          Create a set, or let the AI generate one from a
-                          misconception or study prompt.
-                        </EmptyDescription>
-                      </EmptyContent>
-                    </Empty>
-                  ) : (
-                    orderedSets.map((set) => {
-                      const isSelected = set.id === selectedSetId;
-                      return (
-                        <button
-                          className={cn(
-                            "flex w-full cursor-pointer items-start justify-between gap-3 rounded-md px-3 py-2.5 text-left transition-colors hover:bg-secondary",
-                            isSelected && "bg-secondary"
-                          )}
-                          key={set.id}
-                          onClick={() => setSelectedSetId(set.id)}
-                          onFocus={() => {
-                            prefetchFlashcardSet(set.id).catch(() => undefined);
-                          }}
-                          onMouseEnter={() => {
-                            prefetchFlashcardSet(set.id).catch(() => undefined);
-                          }}
-                          type="button"
-                        >
-                          <div className="min-w-0">
-                            <p className="truncate text-foreground text-sm">
-                              {set.title}
-                            </p>
-                            <p className="mt-1 text-[11px] text-muted-foreground">
-                              {set.dueCount + set.newCount} ready ·{" "}
-                              {set.cardCount} cards
-                            </p>
-                          </div>
-                          {set.dueCount > 0 ? (
-                            <Badge
-                              className="shrink-0 rounded-md"
-                              variant="outline"
-                            >
-                              {set.dueCount} due
-                            </Badge>
-                          ) : null}
-                        </button>
-                      );
-                    })
-                  )}
-                </div>
-              </ScrollArea>
-            )}
-          </div>
-
-          <div className="min-w-0">
-            {selectedSet ? (
-              <div>
-                <div className="pb-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 space-y-1">
-                      <h2 className="truncate font-medium text-[15px] text-foreground md:text-base">
-                        {selectedSet.title}
-                      </h2>
-                      <p className="line-clamp-2 text-muted-foreground text-xs md:text-sm">
-                        {selectedSet.description ?? "No description yet."}
-                      </p>
-                    </div>
-                    {selectedSet.dueCount > 0 ? (
-                      <Badge className="rounded-md" variant="outline">
-                        {selectedSet.dueCount} due
-                      </Badge>
-                    ) : null}
-                  </div>
-                </div>
-                <div className="space-y-4">
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    <div className="rounded-md bg-secondary/30 px-3 py-3 md:px-4">
-                      <p className="text-[11px] text-muted-foreground uppercase tracking-[0.15em]">
-                        Deck profile
-                      </p>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        <Badge className="rounded-md" variant="outline">
-                          {selectedSet.sourceType === "ai-generated"
-                            ? "AI-generated"
-                            : "Manual"}
-                        </Badge>
-                        <Badge className="rounded-md" variant="outline">
-                          {getEnrollmentLabel(selectedSet.enrollmentStatus)}
-                        </Badge>
-                        <Badge className="rounded-md" variant="outline">
-                          {selectedSet.cardCount} cards
-                        </Badge>
-                      </div>
-                      <p className="mt-3 text-muted-foreground text-xs">
-                        {selectedSet.description ?? "No description yet."}
-                      </p>
-                    </div>
-                    <div className="rounded-md bg-secondary/20 px-3 py-3 md:px-4">
-                      <p className="text-[11px] text-muted-foreground uppercase tracking-[0.18em]">
-                        Study context
-                      </p>
-                      <div className="mt-3 space-y-2 text-muted-foreground text-xs">
-                        <p>
-                          {selectedSet.lastStudiedAt
-                            ? `Last studied ${new Date(
-                                selectedSet.lastStudiedAt
-                              ).toLocaleDateString()}`
-                            : "Not studied yet"}
-                        </p>
-                        <p>
-                          Updated{" "}
-                          {new Date(selectedSet.updatedAt).toLocaleDateString()}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                  <StabilityCurves snapshots={selectedSnapshots} />
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="text-[11px] text-muted-foreground uppercase tracking-[0.15em]">
-                        Quick cards
-                      </p>
-                      <p className="text-[11px] text-muted-foreground">
-                        {selectedSnapshots.length} tracked
-                      </p>
-                    </div>
-                    <div className="space-y-2">
-                      {selectedSnapshots.length === 0 ? (
-                        <p className="text-muted-foreground text-xs">
-                          No cards tracked for this deck yet.
-                        </p>
-                      ) : (
-                        selectedSnapshots.slice(0, 3).map((snapshot) => (
-                          <div
-                            className="rounded-md bg-secondary/30 px-3 py-2.5 md:py-3"
-                            key={snapshot.card.id}
-                          >
-                            <div className="flex items-start justify-between gap-3">
-                              <div className="min-w-0">
-                                <p className="line-clamp-2 text-foreground text-sm">
-                                  {snapshot.card.frontMarkdown}
-                                </p>
-                                <p className="mt-1 text-[11px] text-muted-foreground">
-                                  {snapshot.dueAt
-                                    ? `Due ${new Date(snapshot.dueAt).toLocaleDateString()}`
-                                    : "Not scheduled"}
-                                </p>
-                              </div>
-                              <Badge
-                                className="shrink-0 rounded-md"
-                                variant="outline"
-                              >
-                                {snapshot.displayState}
-                              </Badge>
-                            </div>
-                          </div>
-                        ))
-                      )}
-                    </div>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      className="flex-1"
-                      onClick={() =>
-                        router.push(
-                          `/workspace/flashcards/${selectedSet.id}` as Route
-                        )
-                      }
-                      onMouseEnter={() => {
-                        prefetchFlashcardSet(selectedSet.id).catch(
-                          () => undefined
-                        );
-                      }}
-                      type="button"
-                    >
-                      Open deck
-                    </Button>
-                    <Button
-                      onClick={() =>
-                        router.push(
-                          `/workspace/flashcards/${selectedSet.id}` as Route
-                        )
-                      }
-                      onMouseEnter={() => {
-                        prefetchFlashcardSet(selectedSet.id).catch(
-                          () => undefined
-                        );
-                      }}
-                      type="button"
-                      variant="outline"
-                    >
-                      Go
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="px-4 py-8 text-center text-muted-foreground text-xs">
-                Nothing to show yet.
-              </div>
-            )}
-          </div>
-        </motion.div>
-
-        <section className="space-y-3 border-border/50 border-t pt-4">
           <div className="flex items-center justify-between gap-3">
-            <h2 className="font-medium text-foreground text-sm">
-              Misconceptions
+            <h2 className="font-semibold text-foreground text-lg">
+              Continue learning
             </h2>
-            <p className="text-muted-foreground text-xs">
-              {overviewQuery.data?.activeMisconceptions.length ?? 0} active
+            <p className="text-muted-foreground text-sm">
+              {weeklyPlanSets.length} deck
+              {weeklyPlanSets.length === 1 ? "" : "s"}
             </p>
+          </div>
+          {weeklyPlanSets.length === 0 ? (
+            <Empty className="min-h-[12rem]">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <BookOpenCheck className="size-4" />
+                </EmptyMedia>
+                <EmptyTitle>No decks yet</EmptyTitle>
+              </EmptyHeader>
+              <EmptyContent>
+                <EmptyDescription>
+                  Create a deck or generate one from a knowledge gap to start
+                  reviewing.
+                </EmptyDescription>
+              </EmptyContent>
+            </Empty>
+          ) : (
+            <div className="grid gap-8 sm:grid-cols-2 xl:grid-cols-4">
+              {weeklyPlanSets.map((set) => (
+                <button
+                  className="group flex min-h-56 flex-col items-center justify-center px-5 py-6 text-center transition-colors hover:bg-secondary/60"
+                  key={set.id}
+                  onClick={() =>
+                    router.push(`/workspace/flashcards/${set.id}` as Route)
+                  }
+                  onFocus={() => {
+                    prefetchFlashcardSet(set.id).catch(() => undefined);
+                  }}
+                  onMouseEnter={() => {
+                    prefetchFlashcardSet(set.id).catch(() => undefined);
+                  }}
+                  type="button"
+                >
+                  <StrideFileIcon className="size-20 text-muted-foreground transition-colors group-hover:text-foreground" />
+                  <div className="mt-6 min-w-0">
+                    <h3 className="font-medium text-foreground text-base leading-6">
+                      {set.title}
+                    </h3>
+                    <p className="mt-2 text-muted-foreground text-sm">
+                      {set.dueCount + set.newCount} cards due
+                    </p>
+                  </div>
+                  <span className="mt-6 text-muted-foreground text-xs transition-colors group-hover:text-foreground">
+                    Continue
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-5 pb-8" id="knowledge-gaps">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="font-semibold text-foreground text-lg">
+              Knowledge gaps
+            </h2>
+            {activeMisconceptions.length > knowledgeGaps.length ? (
+              <button
+                className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+                onClick={() => {
+                  setSelectedMisconception(activeMisconceptions[0] ?? null);
+                }}
+                type="button"
+              >
+                View all
+              </button>
+            ) : null}
           </div>
           {overviewQuery.isLoading ? (
-            <p className="text-muted-foreground text-xs">
-              Loading misconception memory...
+            <p className="text-muted-foreground text-sm">
+              Loading knowledge gaps...
             </p>
-          ) : overviewQuery.data?.activeMisconceptions.length ? (
-            <div className="space-y-2">
-              {overviewQuery.data.activeMisconceptions
-                .slice(0, 6)
-                .map((misconception) => (
-                  <button
-                    className="grid w-full cursor-pointer gap-2 rounded-md bg-secondary/25 px-3 py-2.5 text-left transition-colors hover:bg-secondary/60 md:gap-3 md:border md:border-border/60 md:bg-card md:py-3 md:grid-cols-[minmax(10rem,0.36fr)_minmax(0,1fr)]"
-                    key={misconception.id}
-                    onClick={() => setSelectedMisconception(misconception)}
-                    type="button"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate font-medium text-foreground text-sm">
-                        {misconception.concept}
-                      </p>
-                      <p className="mt-1 truncate text-muted-foreground text-xs">
-                        {misconception.subject} / {misconception.topic}
-                      </p>
-                    </div>
-                    <div className="min-w-0">
-                      <p className="line-clamp-2 text-muted-foreground text-sm leading-5">
-                        {misconception.reason}
-                      </p>
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        <Badge className="rounded-md" variant="outline">
-                          {Math.round(misconception.confidence * 100)}%
-                        </Badge>
-                        <Badge className="rounded-md" variant="outline">
-                          {misconception.source}
-                        </Badge>
-                      </div>
-                    </div>
-                  </button>
-                ))}
-            </div>
+          ) : knowledgeGaps.length === 0 ? (
+            <p className="py-5 text-muted-foreground text-sm">
+              No active knowledge gaps right now.
+            </p>
           ) : (
-            <p className="rounded-md border border-border/60 bg-card px-3 py-3 text-muted-foreground text-sm">
-              No active misconceptions yet.
-            </p>
+            <div className="divide-y divide-border/60">
+              {knowledgeGaps.map((misconception) => (
+                <button
+                  className="flex w-full items-start gap-5 py-5 text-left transition-colors hover:bg-secondary/40"
+                  key={misconception.id}
+                  onClick={() => setSelectedMisconception(misconception)}
+                  type="button"
+                >
+                  <WarningCircle className="mt-1 size-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-start justify-between gap-4">
+                      <h3 className="font-medium text-foreground text-base">
+                        {misconception.concept}
+                      </h3>
+                      <p className="shrink-0 text-muted-foreground text-sm tabular-nums">
+                        {Math.round(misconception.confidence * 100)}%
+                      </p>
+                    </div>
+                    <p className="mt-2 text-muted-foreground text-sm leading-6">
+                      {getMisconceptionSummary(misconception)}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
           )}
         </section>
       </div>
-      <Dialog
-        onOpenChange={(open) => {
-          if (!open) {
-            setSelectedMisconception(null);
-            if (searchParams.get("misconception")) {
-              const params = new URLSearchParams(searchParams.toString());
-              params.delete("misconception");
-              const query = params.toString();
-              router.replace(
-                (query ? `${pathname}?${query}` : pathname) as Route
-              );
+      {isMobile ? (
+        <Drawer
+          direction="bottom"
+          onOpenChange={(open) => {
+            if (!open) {
+              closeSelectedMisconception();
             }
-          }
-        }}
-        open={selectedMisconception !== null}
-      >
-        <DialogContent className="h-[100dvh] w-screen max-w-none overflow-hidden rounded-none border-0 p-0 sm:h-[92vh] sm:w-[96vw] sm:max-w-[1200px] sm:rounded-xl sm:border lg:max-w-[1280px]">
-          {selectedMisconception ? (
-            <div className="flex h-full min-h-0 flex-col bg-background">
-              <DialogHeader className="border-border/50 border-b px-5 py-5 sm:px-8 sm:py-7">
-                <DialogTitle className="max-w-4xl text-balance font-semibold text-2xl leading-tight sm:text-3xl">
-                  {selectedMisconception.concept}
-                </DialogTitle>
-                <DialogDescription className="text-sm sm:text-base">
-                  {selectedMisconception.subject} /{" "}
-                  {selectedMisconception.topic}
-                </DialogDescription>
-              </DialogHeader>
-              <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-8 sm:py-8">
-                <div className="grid w-full gap-10 lg:grid-cols-[minmax(0,1fr)_22rem]">
-                  <div className="max-w-4xl space-y-8">
-                    <section>
-                      <h3 className="font-medium text-muted-foreground text-sm">
-                        Misconception summary
-                      </h3>
-                      <p className="mt-3 text-foreground text-xl leading-8">
-                        {selectedMisconception.blocks?.summary ??
-                          selectedMisconception.reason}
-                      </p>
-                    </section>
-                    <section className="border-border/50 border-t pt-6">
-                      <h3 className="font-medium text-muted-foreground text-sm">
-                        Corrected mental model
-                      </h3>
-                      <p className="mt-3 text-foreground text-base leading-7">
-                        {selectedMisconception.blocks?.correctedMentalModel ??
-                          "Open this with AI to build a corrected model from the misconception evidence."}
-                      </p>
-                    </section>
-                    <section className="border-border/50 border-t pt-6">
-                      <h3 className="font-medium text-muted-foreground text-sm">
-                        Short explanation
-                      </h3>
-                      <p className="mt-3 text-muted-foreground text-base leading-7">
-                        {selectedMisconception.blocks?.explanation ??
-                          selectedMisconception.reason}
-                      </p>
-                    </section>
-                  </div>
-                  <aside className="space-y-5">
-                    <div className="border-border/50 border-b pb-5">
-                      <div className="flex items-baseline justify-between gap-3">
-                        <p className="font-medium text-muted-foreground text-sm">
-                          Concept confidence
-                        </p>
-                        <p className="font-semibold text-foreground text-2xl">
-                          {Math.round(selectedMisconception.confidence * 100)}%
-                        </p>
-                      </div>
-                      <p className="mt-2 text-muted-foreground text-xs leading-5">
-                        Estimate of how stable the learner's understanding is
-                        for this concept.
-                      </p>
-                      <div className="mt-3 grid grid-cols-2 gap-2">
-                        <Button
-                          className="justify-center"
-                          onClick={() =>
-                            adjustMisconceptionConfidence(
-                              selectedMisconception,
-                              -0.1
-                            ).catch(() => undefined)
-                          }
-                          type="button"
-                          variant="outline"
-                        >
-                          Decrease
-                        </Button>
-                        <Button
-                          className="justify-center"
-                          onClick={() =>
-                            adjustMisconceptionConfidence(
-                              selectedMisconception,
-                              0.1
-                            ).catch(() => undefined)
-                          }
-                          type="button"
-                          variant="outline"
-                        >
-                          Increase
-                        </Button>
-                      </div>
-                    </div>
-                    <Button
-                      className="w-full justify-start"
-                      onClick={() => {
-                        const prompt = promptForMisconception(
-                          selectedMisconception
-                        );
-                        router.push(`/workspace/chats/new?prompt=${prompt}`);
-                      }}
-                      type="button"
-                      variant="outline"
-                    >
-                      <MessageSquareText className="size-4" />
-                      Method with AI
-                    </Button>
-                    <Button
-                      className="w-full justify-start"
-                      onClick={() => {
-                        const prompt = promptForFlashcards(
-                          selectedMisconception
-                        );
-                        router.push(`/workspace/chats/new?prompt=${prompt}`);
-                      }}
-                      type="button"
-                      variant="outline"
-                    >
-                      <BookOpenCheck className="size-4" />
-                      Generate mindset
-                    </Button>
-                    <Button
-                      className="w-full justify-start"
-                      onClick={() => {
-                        clearMisconception(selectedMisconception).catch(
-                          () => undefined
-                        );
-                      }}
-                      type="button"
-                      variant="destructive"
-                    >
-                      Clear misconception
-                    </Button>
-                  </aside>
-                </div>
-              </div>
+          }}
+          open={selectedMisconception !== null}
+        >
+          <DrawerContent className="data-[vaul-drawer-direction=bottom]:max-h-[86dvh]">
+            <div className="flex h-full max-h-[inherit] min-h-0 flex-col overflow-hidden">
+              {renderMisconceptionPanel()}
             </div>
-          ) : null}
-        </DialogContent>
-      </Dialog>
+          </DrawerContent>
+        </Drawer>
+      ) : (
+        <Dialog
+          onOpenChange={(open) => {
+            if (!open) {
+              closeSelectedMisconception();
+            }
+          }}
+          open={selectedMisconception !== null}
+        >
+          <DialogContent className="flex max-h-[88dvh] w-[min(calc(100vw-2rem),58rem)] max-w-none flex-col gap-0 overflow-hidden rounded-lg border border-border/60 p-0 shadow-surface-8">
+            {renderMisconceptionPanel()}
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/flashcards/dashboard.tsx
+++ b/apps/web/src/components/flashcards/dashboard.tsx
@@ -38,7 +38,6 @@ import { AnimatePresence, motion } from "motion/react";
 import type { Route } from "next";
 import Image from "next/image";
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
-import { Markdown } from "@/components/chat/markdown";
 import {
   HeaderActions,
   HeaderBreadcrumbs,
@@ -133,28 +132,6 @@ function getCorrectedMentalModel(misconception: MisconceptionRecord) {
   return (
     misconception.blocks?.correctedMentalModel ??
     "Open this with AI to build the corrected model from the flagged evidence."
-  );
-}
-
-function DashboardMarkdownPreview({
-  className,
-  content,
-  id,
-}: {
-  className?: string;
-  content: string;
-  id: string;
-}) {
-  return (
-    <Markdown
-      className={cn(
-        "max-w-none text-inherit leading-[1.45] [&_*]:my-0 [&_code:not(pre_code)]:rounded-md [&_code:not(pre_code)]:bg-muted [&_code:not(pre_code)]:px-1 [&_li]:my-0 [&_ol]:my-0 [&_ol]:pl-4 [&_p]:my-0 [&_pre]:hidden [&_ul]:my-0 [&_ul]:pl-4",
-        className
-      )}
-      content={content}
-      id={id}
-      parseIncompleteMarkdown={false}
-    />
   );
 }
 

--- a/apps/web/src/components/flashcards/set-detail.tsx
+++ b/apps/web/src/components/flashcards/set-detail.tsx
@@ -282,7 +282,7 @@ function FlashcardMarkdownPreview({
   return (
     <Markdown
       className={cn(
-        "flashcard-preview-markdown max-w-none text-inherit leading-[1.45] [&_*]:my-0 [&_code:not(pre_code)]:rounded [&_code:not(pre_code)]:bg-muted [&_code:not(pre_code)]:px-1 [&_code:not(pre_code)]:py-0.5 [&_code:not(pre_code)]:text-[0.9em] [&_li]:my-0 [&_ol]:my-0 [&_ol]:pl-4 [&_p]:my-0 [&_pre]:hidden [&_ul]:my-0 [&_ul]:pl-4",
+        "flashcard-preview-markdown max-w-none text-inherit leading-[1.45] [&_*]:my-0 [&_code:not(pre_code)]:rounded [&_code:not(pre_code)]:bg-muted [&_code:not(pre_code)]:px-1 [&_code:not(pre_code)]:py-0.5 [&_code:not(pre_code)]:text-[0.9em] [&_li]:my-0 [&_ol]:my-0 [&_ol]:pl-4 [&_p]:my-0 [&_pre]:max-h-20 [&_pre]:overflow-hidden [&_ul]:my-0 [&_ul]:pl-4",
         className
       )}
       content={content}

--- a/apps/web/src/components/flashcards/set-detail.tsx
+++ b/apps/web/src/components/flashcards/set-detail.tsx
@@ -270,6 +270,28 @@ function StudyCardFace({
   );
 }
 
+function FlashcardMarkdownPreview({
+  className,
+  content,
+  id,
+}: {
+  className?: string;
+  content: string;
+  id: string;
+}) {
+  return (
+    <Markdown
+      className={cn(
+        "flashcard-preview-markdown max-w-none text-inherit leading-[1.45] [&_*]:my-0 [&_code:not(pre_code)]:rounded [&_code:not(pre_code)]:bg-muted [&_code:not(pre_code)]:px-1 [&_code:not(pre_code)]:py-0.5 [&_code:not(pre_code)]:text-[0.9em] [&_li]:my-0 [&_ol]:my-0 [&_ol]:pl-4 [&_p]:my-0 [&_pre]:hidden [&_ul]:my-0 [&_ul]:pl-4",
+        className
+      )}
+      content={content}
+      id={id}
+      parseIncompleteMarkdown={false}
+    />
+  );
+}
+
 export function FlashcardSetDetail({
   initialDrillFilters,
   initialQueue,
@@ -849,9 +871,17 @@ export function FlashcardSetDetail({
                     <h1 className="text-balance font-semibold text-xl leading-tight tracking-tight">
                       {set.title}
                     </h1>
-                    <p className="text-muted-foreground text-sm md:text-sm">
-                      {set.description ?? "No description set for this deck."}
-                    </p>
+                    {set.description ? (
+                      <FlashcardMarkdownPreview
+                        className="line-clamp-2 text-muted-foreground text-sm"
+                        content={set.description}
+                        id={`set-description-${set.id}`}
+                      />
+                    ) : (
+                      <p className="text-muted-foreground text-sm">
+                        No description set for this deck.
+                      </p>
+                    )}
                   </div>
                   {drillFilters.length > 0 ? (
                     <div className="rounded-lg border border-amber-200/80 bg-amber-50/80 px-3 py-2 text-xs dark:border-amber-400/20 dark:bg-amber-500/10">
@@ -1185,10 +1215,10 @@ export function FlashcardSetDetail({
                     {studySessionContent}
                   </div>
 
-                  <div className="space-y-1.5 px-0.5 pb-0.5">
+                  <div className="rounded-md border border-border bg-card p-2 sm:p-2.5">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <Button
-                        className="h-6 rounded-md px-2.5 text-xs"
+                        className="h-8 rounded-md px-3 text-xs"
                         disabled={!activeCard}
                         onClick={() =>
                           flipReviewCard(studyRevealed ? "front" : "back")
@@ -1278,12 +1308,16 @@ export function FlashcardSetDetail({
                         <TableRow key={card.id}>
                           <TableCell className="align-top">
                             <div className="space-y-2">
-                              <p className="line-clamp-2 text-foreground text-sm">
-                                {card.frontMarkdown}
-                              </p>
-                              <p className="line-clamp-2 text-muted-foreground text-xs">
-                                {card.backMarkdown}
-                              </p>
+                              <FlashcardMarkdownPreview
+                                className="line-clamp-2 text-foreground text-sm"
+                                content={card.frontMarkdown}
+                                id={`card-bank-front-${card.id}`}
+                              />
+                              <FlashcardMarkdownPreview
+                                className="line-clamp-2 text-muted-foreground text-xs"
+                                content={card.backMarkdown}
+                                id={`card-bank-back-${card.id}`}
+                              />
                             </div>
                           </TableCell>
                           <TableCell className="align-top">
@@ -1363,10 +1397,10 @@ function RatingButton({
   return (
     <Button
       className={cn(
-        "h-7 justify-start rounded-md border px-2.5 font-medium text-[0.72rem] tracking-tight transition-colors sm:justify-center",
+        "h-9 justify-start rounded-md border px-3 font-medium text-[0.78rem] tracking-tight transition-colors sm:justify-center",
         RATING_STYLES[rating],
         disabled &&
-          "border-border/70 bg-muted/30 text-muted-foreground hover:border-border/70 hover:bg-muted/30"
+          "border-border/80 bg-muted/60 text-muted-foreground/80 opacity-100 hover:border-border/80 hover:bg-muted/60"
       )}
       disabled={disabled}
       onClick={onClick}

--- a/apps/web/src/components/flashcards/sidebar-panel.tsx
+++ b/apps/web/src/components/flashcards/sidebar-panel.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Badge } from "@avenire/ui/components/badge";
 import { Button } from "@avenire/ui/components/button";
 import {
   Dialog,
@@ -37,6 +36,7 @@ import {
   ChatCenteredText as MessageSquareDashed,
   PlusCircle,
 } from "@phosphor-icons/react";
+import { cn } from "@avenire/ui/lib/utils";
 import type { Route } from "next";
 import {
   type MouseEvent,
@@ -408,7 +408,7 @@ export function FlashcardsSidebarPanel({
 
       {activeMisconceptions.length > 0 ? (
         <SidebarGroup>
-          <SidebarGroupLabel>Misconceptions</SidebarGroupLabel>
+          <SidebarGroupLabel>Knowledge gaps</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {activeMisconceptions.slice(0, 5).map((misconception) => (
@@ -433,10 +433,10 @@ export function FlashcardsSidebarPanel({
                       );
                     }}
                   >
-                    <Badge className="rounded-md" variant="outline">
-                      {Math.round(misconception.confidence * 100)}%
-                    </Badge>
-                    <span className="truncate">{misconception.concept}</span>
+                    <WarningDot confidence={misconception.confidence} />
+                    <span className="min-w-0 whitespace-normal break-words leading-4">
+                      {misconception.concept}
+                    </span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -446,7 +446,7 @@ export function FlashcardsSidebarPanel({
       ) : null}
 
       <SidebarGroup className="min-h-0 flex-1">
-        <SidebarGroupLabel>Sets</SidebarGroupLabel>
+        <SidebarGroupLabel>Decks</SidebarGroupLabel>
         <SidebarGroupContent>
           <Input
             className="mb-2 hidden h-8"
@@ -505,8 +505,10 @@ export function FlashcardsSidebarPanel({
                       prefetchFlashcardSet(set.id).catch(() => undefined);
                     }}
                   >
-                    <SparklineChip due={set.dueCount} newCount={set.newCount} />
-                    <span className="truncate">{set.title}</span>
+                    <DeckCountChip due={set.dueCount} newCount={set.newCount} />
+                    <span className="min-w-0 whitespace-normal break-words leading-4">
+                      {set.title}
+                    </span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -518,11 +520,28 @@ export function FlashcardsSidebarPanel({
   );
 }
 
-function SparklineChip({ due, newCount }: { due: number; newCount: number }) {
+function WarningDot({ confidence }: { confidence: number }) {
   return (
-    <span className="inline-flex items-center gap-1">
-      <Badge variant="outline">{due}</Badge>
-      <Badge variant="secondary">{newCount}</Badge>
+    <span
+      aria-hidden="true"
+      className={cn(
+        "size-1.5 shrink-0 rounded-full",
+        confidence >= 0.9
+          ? "bg-destructive"
+          : confidence >= 0.75
+            ? "bg-amber-500"
+            : "bg-emerald-500"
+      )}
+    />
+  );
+}
+
+function DeckCountChip({ due, newCount }: { due: number; newCount: number }) {
+  const total = due + newCount;
+
+  return (
+    <span className="inline-flex min-w-6 shrink-0 justify-center rounded-md border border-border/70 px-1.5 py-0.5 text-[10px] text-muted-foreground tabular-nums">
+      {total}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- keep the mobile dock hidden when the chat composer remains open after native file-picker visibility changes
- restore the chat composer shell to a fully rounded shape while keeping the recent shared surface styling
- includes the requested workspace shell and mindset polish commits

## Validation
- pnpm --filter @avenire/web check-types
- git diff --check main..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Ready to review" section and performance overview metrics to the flashcard dashboard.
  * Introduced knowledge gaps section for browsing and fixing misconceptions.
  * Added markdown preview support for flashcard content.

* **Improvements**
  * Enhanced mobile chat composer to auto-close when navigating between pages.
  * Refined UI styling for visual consistency across components.
  * Improved attachment preview rendering and thumbnail display.
  * Updated sidebar to better visualize knowledge gaps and deck information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->