### PR TITLE
Fix register resend clock snapshot

### DIFF
--- a/packages/auth/components/register.tsx
+++ b/packages/auth/components/register.tsx
@@ -18,12 +18,14 @@ const VERIFICATION_EMAIL_STORAGE_KEY = "auth:verification-email"
 
 const clockSubscribers = new Set<() => void>()
 let clockInterval: number | null = null
+let clockSnapshot = Date.now()
 
 function subscribeToClock(callback: () => void) {
   clockSubscribers.add(callback)
 
   if (!clockInterval) {
     clockInterval = window.setInterval(() => {
+      clockSnapshot = Date.now()
       clockSubscribers.forEach((subscriber) => subscriber())
     }, 1000)
   }
@@ -39,7 +41,7 @@ function subscribeToClock(callback: () => void) {
 }
 
 function useClockNow() {
-  return useSyncExternalStore(subscribeToClock, () => Date.now(), () => 0)
+  return useSyncExternalStore(subscribeToClock, () => clockSnapshot, () => 0)
 }
 
 function getVerificationCooldownStorageKey(email: string) {


### PR DESCRIPTION
## Summary
- cache the register form resend cooldown clock snapshot for useSyncExternalStore
- update the cached snapshot only when the clock interval notifies subscribers

## Verification
- pnpm --filter @avenire/auth check-types
- pnpm --filter @avenire/web check-types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of email verification resend cooldown to better integrate with React's reactive system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->