### PR TITLE
Fix PDF viewer worker source

### DIFF
--- a/apps/web/src/components/files/pdf-viewer.tsx
+++ b/apps/web/src/components/files/pdf-viewer.tsx
@@ -18,8 +18,16 @@ import { Button } from "@avenire/ui/components/button";
 import { cn } from "@avenire/ui/lib/utils";
 import { ArrowLeft, ArrowRight } from "@phosphor-icons/react";
 import { m } from "framer-motion";
+import { GlobalWorkerOptions } from "pdfjs-dist";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "pdfjs-dist/web/pdf_viewer.css";
+
+if (!GlobalWorkerOptions.workerSrc) {
+  GlobalWorkerOptions.workerSrc = new URL(
+    "pdfjs-dist/build/pdf.worker.mjs",
+    import.meta.url
+  ).toString();
+}
 
 function normalizePdfSearchText(value: string) {
   return value


### PR DESCRIPTION
## Summary
- configure pdf.js worker source in the PDF viewer module before Lector renders PDFs
- prevents runtime failures when the package patch is not applied or pdf.js is loaded without a worker source

## Test
- pnpm --filter @avenire/web check-types