### PR TITLE
fix: restore pdf zoom dock input resets, upgrade kimi-k2p5 to k2p7-code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,8 @@ CHAT_TOKENS_PER_CREDIT=1000
 WIDGET_GENERATION_CREDITS=20
 # Turbo models such as apex-turbo/K2.6 Turbo charge this multiplier on model token usage.
 TURBO_MODEL_CREDIT_MULTIPLIER=2
+# Apex models such as apollo-apex/K2.7 Code charge this multiplier on model token usage.
+APEX_MODEL_CREDIT_MULTIPLIER=1.5
 # Dev-only chat route profiling. Adds profileAt, profileEpochMs, and profileProcessMs to api/chat logs.
 CHAT_PROFILE_LOGS=false
 CHAT_TITLE_MODEL=

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -77,6 +77,7 @@ const DEFAULT_CHAT_TOKENS_PER_CREDIT = 1000;
 const DEFAULT_EXPECTED_OUTPUT_TOKENS = 2000;
 const DEFAULT_WIDGET_GENERATION_CREDITS = 20;
 const DEFAULT_TURBO_MODEL_CREDIT_MULTIPLIER = 2;
+const DEFAULT_APEX_MODEL_CREDIT_MULTIPLIER = 1.5;
 const DEFAULT_CHAT_TITLE_MODEL: ApolloModelName = "apollo-meta";
 const LEARNING_CONTEXT_CACHE_PREFIX = "chat-learning-context:v1:";
 const LEARNING_CONTEXT_CACHE_TTL_SECONDS = 60 * 60 * 3;
@@ -1007,14 +1008,24 @@ function resolveTurboModelCreditMultiplier() {
   return raw;
 }
 
-function modelUsesTurboCreditMultiplier(model: ApolloModelName) {
-  return model === "apex-turbo";
+function resolveApexModelCreditMultiplier() {
+  const raw = Number.parseFloat(
+    process.env.APEX_MODEL_CREDIT_MULTIPLIER ?? ""
+  );
+  if (!Number.isFinite(raw) || raw < 1) {
+    return DEFAULT_APEX_MODEL_CREDIT_MULTIPLIER;
+  }
+  return raw;
 }
 
 function getModelCreditMultiplier(model: ApolloModelName) {
-  return modelUsesTurboCreditMultiplier(model)
-    ? resolveTurboModelCreditMultiplier()
-    : 1;
+  if (model === "apex-turbo") {
+    return resolveTurboModelCreditMultiplier();
+  }
+  if (model === "apollo-apex") {
+    return resolveApexModelCreditMultiplier();
+  }
+  return 1;
 }
 
 function resolveTotalTokens(usage: {

--- a/apps/web/src/components/files/pdf-viewer.tsx
+++ b/apps/web/src/components/files/pdf-viewer.tsx
@@ -160,6 +160,14 @@ function PdfFloatingDock() {
   );
 
   useEffect(() => {
+    setPageInput("");
+  }, [resolvedPage]);
+
+  useEffect(() => {
+    setZoomInput("");
+  }, [resolvedZoom]);
+
+  useEffect(() => {
     const node = viewportRef.current;
     if (!node) {
       return;

--- a/packages/ai/models/index.ts
+++ b/packages/ai/models/index.ts
@@ -31,7 +31,7 @@ export type ApolloModelName =
 
 export const APOLLO_LANGUAGE_MODEL_IDS: Record<ApolloModelName, string> = {
   "apollo-agent": "accounts/fireworks/models/glm-5",
-  "apollo-apex": "accounts/fireworks/models/kimi-k2p5",
+  "apollo-apex": "accounts/fireworks/models/kimi-k2p7-code",
   "apex-turbo": "accounts/fireworks/routers/kimi-k2p6-turbo",
   "apollo-core": "gemini-3-flash-preview",
   "apollo-meta": "openai/gpt-oss-120b",

--- a/packages/env-types/index.d.ts
+++ b/packages/env-types/index.d.ts
@@ -5,6 +5,7 @@ declare namespace NodeJS {
   // biome-ignore assist/source/useSortedInterfaceMembers: Members are generated from sorted environment keys.
   interface ProcessEnv {
     ADMIN_API_TOKEN?: string;
+    APEX_MODEL_CREDIT_MULTIPLIER?: string;
     AUTH_GITHUB_ID?: string;
     AUTH_GITHUB_SECRET?: string;
     AUTH_GOOGLE_ID?: string;


### PR DESCRIPTION

- Re-adds the two useEffect hooks in PdfFloatingDock that reset pageInput/zoomInput when resolved values change (were dropped in 93cb29a)
- Switches apollo-apex model from deprecated kimi-k2p5 to kimi-k2p7-code
- Adds a 1.5x credit multiplier for apollo-apex to account for the new model's higher per-token cost


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDF viewer input handling improved - page number and zoom percentage fields now reset appropriately when changing pages or zoom levels.

* **Chores**
  * Updated language model backend configurations and credit multiplier calculations for enhanced system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->