### PR TITLE
Add desktop workspace tabs

### DIFF
--- a/apps/web/src/components/dashboard/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard/app-sidebar.tsx
@@ -2,6 +2,12 @@
 
 import { Button } from "@avenire/ui/components/button";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@avenire/ui/components/context-menu";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -40,6 +46,7 @@ import {
 } from "@avenire/ui/components/tooltip";
 import { cn } from "@avenire/ui/lib/utils";
 import {
+  Columns,
   Files,
   GitBranch,
   ListChecks,
@@ -48,9 +55,10 @@ import {
   DotsThree as MoreHorizontal,
   SidebarSimpleIcon as PanelLeftIcon,
   Pencil,
+  Plus,
+  PlusCircle,
   PushPin as Pin,
   PushPinSlash as PinOff,
-  PlusCircle,
   Gear as Settings,
   Sparkle as Sparkles,
   Trash as Trash2,
@@ -243,14 +251,16 @@ async function sendChatSessionClose(payload: {
 }
 
 function SectionButton({
+  contextMenuContent,
   dragHref,
   icon: Icon,
   description,
   label,
   size = "default",
   onClick,
-  onContextMenu,
+  onContextMenu: _onContextMenu,
 }: {
+  contextMenuContent?: ReactNode;
   dragHref?: Route;
   icon: ComponentType<{ className?: string }>;
   description?: string;
@@ -259,33 +269,46 @@ function SectionButton({
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onContextMenu?: (event: MouseEvent<HTMLButtonElement>) => void;
 }) {
-  return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
-        draggable={Boolean(dragHref)}
-        onClick={onClick}
-        onContextMenu={onContextMenu}
-        onDragStart={(event) => {
-          if (!dragHref) {
-            return;
-          }
+  const button = (
+    <SidebarMenuButton
+      draggable={Boolean(dragHref)}
+      onClick={onClick}
+      onContextMenu={_onContextMenu}
+      onDragStart={(event) => {
+        if (!dragHref) {
+          return;
+        }
 
-          setWorkspacePaneDragData(event.dataTransfer, dragHref);
-        }}
-        size={size}
-      >
-        <Icon className="size-3.5" />
-        <div className="min-w-0 flex-1 text-left">
-          <p className="truncate text-[11px]">{label}</p>
-          {description ? (
-            <p className="truncate text-[10px] text-muted-foreground">
-              {description}
-            </p>
-          ) : null}
-        </div>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
+        setWorkspacePaneDragData(event.dataTransfer, dragHref);
+      }}
+      size={size}
+    >
+      <Icon className="size-3.5" />
+      <div className="min-w-0 flex-1 text-left">
+        <p className="truncate text-[11px]">{label}</p>
+        {description ? (
+          <p className="truncate text-[10px] text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+      </div>
+    </SidebarMenuButton>
   );
+
+  if (contextMenuContent) {
+    return (
+      <SidebarMenuItem>
+        <ContextMenu>
+          <ContextMenuTrigger render={<div className="contents" />}>
+            {button}
+          </ContextMenuTrigger>
+          <ContextMenuContent>{contextMenuContent}</ContextMenuContent>
+        </ContextMenu>
+      </SidebarMenuItem>
+    );
+  }
+
+  return <SidebarMenuItem>{button}</SidebarMenuItem>;
 }
 
 function SidebarEmptyState({
@@ -409,6 +432,7 @@ function ChatListSection({
   onCancelRename,
   onSelect,
   onSelectInNewPane,
+  onSelectInNewTab,
   onTogglePin,
   onDelete,
   pendingChatSlug,
@@ -424,6 +448,7 @@ function ChatListSection({
   onCancelRename: () => void;
   onSelect: (chatSlug: string) => void;
   onSelectInNewPane?: (chatSlug: string) => void;
+  onSelectInNewTab?: (chatSlug: string) => void;
   onTogglePin: (chatSlug: string, pinned: boolean) => void;
   onDelete: (chatSlug: string) => void;
   pendingChatSlug: string | null;
@@ -552,6 +577,7 @@ function ChatListSection({
                       onFinishRename={onFinishRename}
                       onSelect={onSelect}
                       onSelectInNewPane={onSelectInNewPane}
+                      onSelectInNewTab={onSelectInNewTab}
                       onStartRename={onStartRename}
                       onTogglePin={onTogglePin}
                       pendingChatSlug={pendingChatSlug}
@@ -579,6 +605,7 @@ function ChatListItem({
   onCancelRename,
   onSelect,
   onSelectInNewPane,
+  onSelectInNewTab,
   onTogglePin,
   onDelete,
 }: {
@@ -593,12 +620,54 @@ function ChatListItem({
   onCancelRename: () => void;
   onSelect: (chatSlug: string) => void;
   onSelectInNewPane?: (chatSlug: string) => void;
+  onSelectInNewTab?: (chatSlug: string) => void;
   onTogglePin: (chatSlug: string, pinned: boolean) => void;
   onDelete: (chatSlug: string) => void;
 }) {
   const isEditing = editingChatSlug === chat.slug;
   const isPending = pendingChatSlug === chat.slug;
   const iconName = isChatIconName(chat.icon) ? chat.icon : null;
+
+  const button = (
+    <SidebarMenuButton
+      draggable
+      isActive={activeChatSlug === chat.slug}
+      onClick={(event) => {
+        if (event.ctrlKey && event.shiftKey) {
+          event.preventDefault();
+          onSelectInNewTab?.(chat.slug);
+          return;
+        }
+        if (event.altKey) {
+          event.preventDefault();
+          onSelectInNewPane?.(chat.slug);
+          return;
+        }
+        onSelect(chat.slug);
+      }}
+      onDragStart={(event) => {
+        setWorkspacePaneDragData(
+          event.dataTransfer,
+          `/workspace/chats/${chat.slug}` as Route
+        );
+      }}
+    >
+      {chat.branching ? <GitBranch className="size-4" /> : null}
+      {isPending ? (
+        <Spinner className="size-4 text-foreground/80" />
+      ) : iconName ? (
+        <ChatIcon className="text-muted-foreground" name={iconName} />
+      ) : null}
+      <Tooltip>
+        <TooltipTrigger render={<span className="truncate" />}>
+          {chat.title}
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <span className="max-w-72 break-words">{chat.title}</span>
+        </TooltipContent>
+      </Tooltip>
+    </SidebarMenuButton>
+  );
 
   return (
     <SidebarMenuItem key={chat.slug}>
@@ -626,43 +695,31 @@ function ChatListItem({
         </form>
       ) : (
         <>
-          <SidebarMenuButton
-            draggable
-            isActive={activeChatSlug === chat.slug}
-            onClick={(event) => {
-              if (event.altKey) {
-                event.preventDefault();
-                onSelectInNewPane?.(chat.slug);
-                return;
-              }
-              onSelect(chat.slug);
-            }}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              onSelectInNewPane?.(chat.slug);
-            }}
-            onDragStart={(event) => {
-              setWorkspacePaneDragData(
-                event.dataTransfer,
-                `/workspace/chats/${chat.slug}` as Route
-              );
-            }}
-          >
-            {chat.branching ? <GitBranch className="size-4" /> : null}
-            {isPending ? (
-              <Spinner className="size-4 text-foreground/80" />
-            ) : iconName ? (
-              <ChatIcon className="text-muted-foreground" name={iconName} />
-            ) : null}
-            <Tooltip>
-              <TooltipTrigger render={<span className="truncate" />}>
-                {chat.title}
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                <span className="max-w-72 break-words">{chat.title}</span>
-              </TooltipContent>
-            </Tooltip>
-          </SidebarMenuButton>
+          <ContextMenu>
+            <ContextMenuTrigger render={<div className="contents" />}>
+              {button}
+            </ContextMenuTrigger>
+            <ContextMenuContent>
+              <ContextMenuItem
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onSelectInNewPane?.(chat.slug);
+                }}
+              >
+                <Columns className="mr-2 size-3.5" />
+                Open in new pane
+              </ContextMenuItem>
+              <ContextMenuItem
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onSelectInNewTab?.(chat.slug);
+                }}
+              >
+                <Plus className="mr-2 size-3.5" />
+                Open in new tab
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
 
           {chat.readOnly ? null : (
             <DropdownMenu>
@@ -1484,7 +1541,7 @@ export function DashboardSidebar({
   );
 
   const navigateToFilesRoot = useCallback(
-    async (options?: { openInNewPane?: boolean }) => {
+    async (options?: { openInNewPane?: boolean; openInNewTab?: boolean }) => {
       try {
         const preferredWorkspaceId =
           typeof window !== "undefined"
@@ -1837,7 +1894,7 @@ export function DashboardSidebar({
   };
 
   useHotkey(
-    "Mod+1",
+    "Mod+Shift+1",
     (event) => {
       event.preventDefault();
       if (!isChatsRoute) {
@@ -1854,7 +1911,7 @@ export function DashboardSidebar({
   );
 
   useHotkey(
-    "Mod+2",
+    "Mod+Shift+2",
     (event) => {
       event.preventDefault();
       if (!pathname.startsWith("/workspace/flashcards")) {
@@ -1866,7 +1923,7 @@ export function DashboardSidebar({
   );
 
   useHotkey(
-    "Mod+3",
+    "Mod+Shift+3",
     (event) => {
       event.preventDefault();
       if (!pathname.startsWith("/workspace/tasks")) {
@@ -1878,7 +1935,7 @@ export function DashboardSidebar({
   );
 
   useHotkey(
-    "Mod+4",
+    "Mod+Shift+4",
     (event) => {
       event.preventDefault();
       if (!pathname.startsWith("/workspace/files")) {
@@ -2117,18 +2174,70 @@ export function DashboardSidebar({
               <ExpandableTabs
                 allowDeselect={false}
                 className="mt-0.5"
+                contextMenuContent={(item) => {
+                  const href = (() => {
+                    switch (item.value) {
+                      case "chat":
+                        return primaryChatRoute;
+                      case "flashcards":
+                        return "/workspace/flashcards" as Route;
+                      case "tasks":
+                        return "/workspace/tasks" as Route;
+                      case "files":
+                        return primaryFilesRoute;
+                      default:
+                        return "/workspace" as Route;
+                    }
+                  })();
+
+                  return (
+                    <>
+                      <ContextMenuItem
+                        onClick={() => navigate(href, { openInNewPane: true })}
+                      >
+                        <Columns className="mr-2 size-3.5" />
+                        Open in new pane
+                      </ContextMenuItem>
+                      <ContextMenuItem
+                        onClick={() => navigate(href, { openInNewTab: true })}
+                      >
+                        <Plus className="mr-2 size-3.5" />
+                        Open in new tab
+                      </ContextMenuItem>
+                    </>
+                  );
+                }}
                 items={[
                   { value: "chat", label: "Method", icon: MessageSquare },
                   { value: "flashcards", label: "Mindset", icon: Sparkles },
                   { value: "tasks", label: "Tasks", icon: ListChecks },
                   { value: "files", label: "Manage", icon: Files },
                 ]}
-                onItemClick={(item, _event) => {
+                onItemClick={(item, event) => {
                   const nextView = item.value as
                     | "chat"
                     | "flashcards"
                     | "files"
                     | "tasks";
+
+                  if (event.ctrlKey && event.shiftKey) {
+                    const href = (() => {
+                      switch (item.value) {
+                        case "chat":
+                          return primaryChatRoute;
+                        case "flashcards":
+                          return "/workspace/flashcards" as Route;
+                        case "tasks":
+                          return "/workspace/tasks" as Route;
+                        case "files":
+                          return primaryFilesRoute;
+                        default:
+                          return "/workspace" as Route;
+                      }
+                    })();
+                    navigate(href, { openInNewTab: true });
+                    return;
+                  }
 
                   if (isMobile) {
                     setMobileSidebarView(nextView);
@@ -2184,31 +2293,82 @@ export function DashboardSidebar({
                     <SidebarGroupContent>
                       <SidebarMenu>
                         <SectionButton
+                          contextMenuContent={
+                            <>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  navigate(createFreshNewChatHref(), {
+                                    openInNewPane: true,
+                                  })
+                                }
+                              >
+                                <Columns className="mr-2 size-3.5" />
+                                Open in new pane
+                              </ContextMenuItem>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  navigate(createFreshNewChatHref(), {
+                                    openInNewTab: true,
+                                  })
+                                }
+                              >
+                                <Plus className="mr-2 size-3.5" />
+                                Open in new tab
+                              </ContextMenuItem>
+                            </>
+                          }
                           dragHref={"/workspace/chats/new" as Route}
                           icon={MessageSquare}
                           label="Open Method"
                           onClick={(event) => {
                             closeMobileSidebar();
+                            if (event.ctrlKey && event.shiftKey) {
+                              navigate(createFreshNewChatHref(), {
+                                openInNewTab: true,
+                              });
+                              return;
+                            }
                             navigate(createFreshNewChatHref(), {
                               openInNewPane: !isMobile && event.altKey,
                             });
                           }}
-                          onContextMenu={(event) => {
-                            if (isMobile) {
-                              return;
-                            }
-                            event.preventDefault();
-                            navigate(createFreshNewChatHref(), {
-                              openInNewPane: true,
-                            });
-                          }}
                         />
                         <SectionButton
+                          contextMenuContent={
+                            <>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  navigate("/workspace/flashcards" as Route, {
+                                    openInNewPane: true,
+                                  })
+                                }
+                              >
+                                <Columns className="mr-2 size-3.5" />
+                                Open in new pane
+                              </ContextMenuItem>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  navigate("/workspace/flashcards" as Route, {
+                                    openInNewTab: true,
+                                  })
+                                }
+                              >
+                                <Plus className="mr-2 size-3.5" />
+                                Open in new tab
+                              </ContextMenuItem>
+                            </>
+                          }
                           dragHref={"/workspace/flashcards" as Route}
                           icon={Sparkles}
                           label="Open Mindset"
                           onClick={(event) => {
                             closeMobileSidebar();
+                            if (event.ctrlKey && event.shiftKey) {
+                              navigate("/workspace/flashcards" as Route, {
+                                openInNewTab: true,
+                              });
+                              return;
+                            }
                             if (!isMobile) {
                               setDesktopSidebarView("flashcards");
                               navigate("/workspace/flashcards" as Route, {
@@ -2220,23 +2380,43 @@ export function DashboardSidebar({
                               openInNewPane: false,
                             });
                           }}
-                          onContextMenu={(event) => {
-                            if (isMobile) {
-                              return;
-                            }
-                            event.preventDefault();
-                            setDesktopSidebarView("flashcards");
-                            navigate("/workspace/flashcards" as Route, {
-                              openInNewPane: true,
-                            });
-                          }}
                         />
                         <SectionButton
+                          contextMenuContent={
+                            <>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  void navigateToFilesRoot({
+                                    openInNewPane: true,
+                                  })
+                                }
+                              >
+                                <Columns className="mr-2 size-3.5" />
+                                Open in new pane
+                              </ContextMenuItem>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  void navigateToFilesRoot({
+                                    openInNewTab: true,
+                                  })
+                                }
+                              >
+                                <Plus className="mr-2 size-3.5" />
+                                Open in new tab
+                              </ContextMenuItem>
+                            </>
+                          }
                           dragHref={primaryFilesRoute}
                           icon={Files}
                           label="Open Manage"
                           onClick={(event) => {
                             closeMobileSidebar();
+                            if (event.ctrlKey && event.shiftKey) {
+                              void navigateToFilesRoot({
+                                openInNewTab: true,
+                              });
+                              return;
+                            }
                             if (!isMobile) {
                               setDesktopSidebarView("files");
                               void navigateToFilesRoot({
@@ -2248,32 +2428,45 @@ export function DashboardSidebar({
                               openInNewPane: false,
                             });
                           }}
-                          onContextMenu={(event) => {
-                            if (isMobile) {
-                              return;
-                            }
-                            event.preventDefault();
-                            setDesktopSidebarView("files");
-                            void navigateToFilesRoot({ openInNewPane: true });
-                          }}
                         />
                         <SectionButton
+                          contextMenuContent={
+                            <>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  navigate("/workspace/tasks" as Route, {
+                                    openInNewPane: true,
+                                  })
+                                }
+                              >
+                                <Columns className="mr-2 size-3.5" />
+                                Open in new pane
+                              </ContextMenuItem>
+                              <ContextMenuItem
+                                onClick={() =>
+                                  navigate("/workspace/tasks" as Route, {
+                                    openInNewTab: true,
+                                  })
+                                }
+                              >
+                                <Plus className="mr-2 size-3.5" />
+                                Open in new tab
+                              </ContextMenuItem>
+                            </>
+                          }
                           dragHref={"/workspace/tasks" as Route}
                           icon={ListChecks}
                           label="Open Tasks"
                           onClick={(event) => {
                             closeMobileSidebar();
-                            navigate("/workspace/tasks" as Route, {
-                              openInNewPane: !isMobile && event.altKey,
-                            });
-                          }}
-                          onContextMenu={(event) => {
-                            if (isMobile) {
+                            if (event.ctrlKey && event.shiftKey) {
+                              navigate("/workspace/tasks" as Route, {
+                                openInNewTab: true,
+                              });
                               return;
                             }
-                            event.preventDefault();
                             navigate("/workspace/tasks" as Route, {
-                              openInNewPane: true,
+                              openInNewPane: !isMobile && event.altKey,
                             });
                           }}
                         />
@@ -2369,6 +2562,13 @@ export function DashboardSidebar({
                         setEditingTitle("");
                         navigate(`/workspace/chats/${chatSlug}` as Route, {
                           openInNewPane: true,
+                        });
+                      }}
+                      onSelectInNewTab={(chatSlug) => {
+                        setEditingChatSlug(null);
+                        setEditingTitle("");
+                        navigate(`/workspace/chats/${chatSlug}` as Route, {
+                          openInNewTab: true,
                         });
                       }}
                       onStartRename={(chat) => {

--- a/apps/web/src/components/dashboard/sidebar-files-panel.tsx
+++ b/apps/web/src/components/dashboard/sidebar-files-panel.tsx
@@ -2,6 +2,12 @@
 
 import { Button } from "@avenire/ui/components/button";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@avenire/ui/components/context-menu";
+import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -11,10 +17,12 @@ import {
   useSidebar,
 } from "@avenire/ui/components/sidebar";
 import {
+  Columns,
   FilePlus as FilePlus2,
   Files,
   LinkSimple,
   MagnifyingGlass,
+  Plus,
   PushPin as Pin,
   Trash as Trash2,
 } from "@phosphor-icons/react";
@@ -24,6 +32,7 @@ import Image from "next/image";
 import {
   type ComponentType,
   type MouseEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -304,37 +313,52 @@ function collectDescendantFolderIds(
 }
 
 function SectionButton({
+  contextMenuContent,
   dragHref,
   icon: Icon,
   label,
   onClick,
-  onContextMenu,
+  onContextMenu: _onContextMenu,
 }: {
+  contextMenuContent?: ReactNode;
   dragHref?: Route;
   icon: ComponentType<{ className?: string }>;
   label: string;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onContextMenu?: (event: MouseEvent<HTMLButtonElement>) => void;
 }) {
-  return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
-        draggable={Boolean(dragHref)}
-        onClick={onClick}
-        onContextMenu={onContextMenu}
-        onDragStart={(event) => {
-          if (!dragHref) {
-            return;
-          }
+  const button = (
+    <SidebarMenuButton
+      draggable={Boolean(dragHref)}
+      onClick={onClick}
+      onContextMenu={_onContextMenu}
+      onDragStart={(event) => {
+        if (!dragHref) {
+          return;
+        }
 
-          setWorkspacePaneDragData(event.dataTransfer, dragHref);
-        }}
-      >
-        <Icon className="size-4" />
-        <span>{label}</span>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
+        setWorkspacePaneDragData(event.dataTransfer, dragHref);
+      }}
+    >
+      <Icon className="size-4" />
+      <span>{label}</span>
+    </SidebarMenuButton>
   );
+
+  if (contextMenuContent) {
+    return (
+      <SidebarMenuItem>
+        <ContextMenu>
+          <ContextMenuTrigger render={<div className="contents" />}>
+            {button}
+          </ContextMenuTrigger>
+          <ContextMenuContent>{contextMenuContent}</ContextMenuContent>
+        </ContextMenu>
+      </SidebarMenuItem>
+    );
+  }
+
+  return <SidebarMenuItem>{button}</SidebarMenuItem>;
 }
 
 export function FilesSidebarPanel({
@@ -347,7 +371,10 @@ export function FilesSidebarPanel({
   currentFileId?: string;
   currentFolderId?: string;
   emitGlobalFileIntent?: (intent: FilesUiIntent) => void | Promise<void>;
-  navigateToFilesRoot: (options?: { openInNewPane?: boolean }) => Promise<void>;
+  navigateToFilesRoot: (options?: {
+    openInNewPane?: boolean;
+    openInNewTab?: boolean;
+  }) => Promise<void>;
   workspaceUuid: string | null;
 }) {
   const { isMobile } = useSidebar();
@@ -380,10 +407,15 @@ export function FilesSidebarPanel({
         return false;
       }
 
+      if (event.ctrlKey && event.shiftKey) {
+        event.preventDefault();
+        navigate(href, { openInNewTab: true });
+        return true;
+      }
+
       if (event.type === "contextmenu") {
         event.preventDefault();
-        navigate(href, { openInNewPane: true });
-        return true;
+        return false;
       }
 
       if (event.altKey) {
@@ -1087,12 +1119,32 @@ export function FilesSidebarPanel({
         onClick: () => {
           navigateToFolder(folder.id, workspaceUuid);
         },
-        onContextMenu: () => {
-          navigate(
-            `/workspace/files/${workspaceUuid}/folder/${folder.id}` as Route,
-            { openInNewPane: true }
-          );
-        },
+        contextMenuContent: (
+          <>
+            <ContextMenuItem
+              onClick={() =>
+                navigate(
+                  `/workspace/files/${workspaceUuid}/folder/${folder.id}` as Route,
+                  { openInNewPane: true }
+                )
+              }
+            >
+              <Columns className="mr-2 size-3.5" />
+              Open in new pane
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() =>
+                navigate(
+                  `/workspace/files/${workspaceUuid}/folder/${folder.id}` as Route,
+                  { openInNewTab: true }
+                )
+              }
+            >
+              <Plus className="mr-2 size-3.5" />
+              Open in new tab
+            </ContextMenuItem>
+          </>
+        ),
         openIcon: TreeFolderOpenIcon,
         selectedIcon: TreeFolderOpenIcon,
       };
@@ -1126,12 +1178,32 @@ export function FilesSidebarPanel({
         onClick: () => {
           navigateToFile(file.id, file.folderId, workspaceUuid);
         },
-        onContextMenu: () => {
-          navigate(
-            `/workspace/files/${workspaceUuid}/folder/${file.folderId}?file=${file.id}` as Route,
-            { openInNewPane: true }
-          );
-        },
+        contextMenuContent: (
+          <>
+            <ContextMenuItem
+              onClick={() =>
+                navigate(
+                  `/workspace/files/${workspaceUuid}/folder/${file.folderId}?file=${file.id}` as Route,
+                  { openInNewPane: true }
+                )
+              }
+            >
+              <Columns className="mr-2 size-3.5" />
+              Open in new pane
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() =>
+                navigate(
+                  `/workspace/files/${workspaceUuid}/folder/${file.folderId}?file=${file.id}` as Route,
+                  { openInNewTab: true }
+                )
+              }
+            >
+              <Plus className="mr-2 size-3.5" />
+              Open in new tab
+            </ContextMenuItem>
+          </>
+        ),
       });
     }
 
@@ -1192,7 +1264,11 @@ export function FilesSidebarPanel({
             <SectionButton
               icon={FilePlus2}
               label="New Note"
-              onClick={() => {
+              onClick={(event) => {
+                if (event.ctrlKey && event.shiftKey) {
+                  emitFileIntentAfterNavigation("newNote");
+                  return;
+                }
                 emitFileIntentAfterNavigation("newNote");
                 triggerHaptic("selection");
               }}
@@ -1200,7 +1276,11 @@ export function FilesSidebarPanel({
             <SectionButton
               icon={LinkSimple}
               label="Import Link"
-              onClick={() => {
+              onClick={(event) => {
+                if (event.ctrlKey && event.shiftKey) {
+                  emitFileIntentAfterNavigation("importLink");
+                  return;
+                }
                 emitFileIntentAfterNavigation("importLink");
                 triggerHaptic("selection");
               }}
@@ -1216,80 +1296,119 @@ export function FilesSidebarPanel({
             <SidebarGroupLabel>Pinned</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {filteredPinnedFolders.map((item) => (
-                  <SidebarMenuItem key={`pinned-folder-${item.id}`}>
-                    <SidebarMenuButton
-                      draggable
-                      onClick={(event) => {
-                        const href =
-                          `/workspace/files/${item.workspaceId}/folder/${item.id}` as Route;
-                        if (handlePaneIntent(event, href)) {
-                          return;
-                        }
-                        navigateToFolder(item.id, item.workspaceId);
-                      }}
-                      onContextMenu={(event) => {
-                        handlePaneIntent(
-                          event,
-                          `/workspace/files/${item.workspaceId}/folder/${item.id}` as Route
-                        );
-                      }}
-                      onDragStart={(event) => {
-                        setWorkspacePaneDragData(
-                          event.dataTransfer,
-                          `/workspace/files/${item.workspaceId}/folder/${item.id}` as Route
-                        );
-                      }}
-                    >
-                      <Pin className="size-4" />
-                      <span className="truncate">{item.name}</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
-                {filteredPinnedFiles.map((item) => (
-                  <SidebarMenuItem key={`pinned-file-${item.id}`}>
-                    <SidebarMenuButton
-                      draggable={Boolean(item.folderId)}
-                      onClick={(event) => {
-                        if (!item.folderId) {
-                          return;
-                        }
-                        const href =
-                          `/workspace/files/${item.workspaceId}/folder/${item.folderId}?file=${item.id}` as Route;
-                        if (handlePaneIntent(event, href)) {
-                          return;
-                        }
-                        navigateToFile(
-                          item.id,
-                          item.folderId,
-                          item.workspaceId
-                        );
-                      }}
-                      onContextMenu={(event) => {
-                        if (!item.folderId) {
-                          return;
-                        }
-                        handlePaneIntent(
-                          event,
-                          `/workspace/files/${item.workspaceId}/folder/${item.folderId}?file=${item.id}` as Route
-                        );
-                      }}
-                      onDragStart={(event) => {
-                        if (!item.folderId) {
-                          return;
-                        }
-
-                        setWorkspacePaneDragData(
-                          event.dataTransfer,
-                          `/workspace/files/${item.workspaceId}/folder/${item.folderId}?file=${item.id}` as Route
-                        );
-                      }}
-                    >
-                      <Pin className="size-4" />
-                      <span className="truncate">{item.name}</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
+                {filteredPinnedFolders.map((item) => {
+                  const folderHref =
+                    `/workspace/files/${item.workspaceId}/folder/${item.id}` as Route;
+                  return (
+                    <SidebarMenuItem key={`pinned-folder-${item.id}`}>
+                      <ContextMenu>
+                        <ContextMenuTrigger
+                          render={<div className="contents" />}
+                        >
+                          <SidebarMenuButton
+                            draggable
+                            onClick={(event) => {
+                              if (handlePaneIntent(event, folderHref)) {
+                                return;
+                              }
+                              navigateToFolder(item.id, item.workspaceId);
+                            }}
+                            onDragStart={(event) => {
+                              setWorkspacePaneDragData(
+                                event.dataTransfer,
+                                folderHref
+                              );
+                            }}
+                          >
+                            <Pin className="size-4" />
+                            <span className="truncate">{item.name}</span>
+                          </SidebarMenuButton>
+                        </ContextMenuTrigger>
+                        <ContextMenuContent>
+                          <ContextMenuItem
+                            onClick={() =>
+                              navigate(folderHref, { openInNewPane: true })
+                            }
+                          >
+                            <Columns className="mr-2 size-3.5" />
+                            Open in new pane
+                          </ContextMenuItem>
+                          <ContextMenuItem
+                            onClick={() =>
+                              navigate(folderHref, { openInNewTab: true })
+                            }
+                          >
+                            <Plus className="mr-2 size-3.5" />
+                            Open in new tab
+                          </ContextMenuItem>
+                        </ContextMenuContent>
+                      </ContextMenu>
+                    </SidebarMenuItem>
+                  );
+                })}
+                {filteredPinnedFiles.map((item) => {
+                  const fileHref = item.folderId
+                    ? (`/workspace/files/${item.workspaceId}/folder/${item.folderId}?file=${item.id}` as Route)
+                    : undefined;
+                  return (
+                    <SidebarMenuItem key={`pinned-file-${item.id}`}>
+                      <ContextMenu>
+                        <ContextMenuTrigger
+                          render={<div className="contents" />}
+                        >
+                          <SidebarMenuButton
+                            draggable={Boolean(item.folderId)}
+                            onClick={(event) => {
+                              if (!fileHref) {
+                                return;
+                              }
+                              if (handlePaneIntent(event, fileHref)) {
+                                return;
+                              }
+                              navigateToFile(
+                                item.id,
+                                item.folderId!,
+                                item.workspaceId
+                              );
+                            }}
+                            onDragStart={(event) => {
+                              if (!fileHref) {
+                                return;
+                              }
+                              setWorkspacePaneDragData(
+                                event.dataTransfer,
+                                fileHref
+                              );
+                            }}
+                          >
+                            <Pin className="size-4" />
+                            <span className="truncate">{item.name}</span>
+                          </SidebarMenuButton>
+                        </ContextMenuTrigger>
+                        {fileHref ? (
+                          <ContextMenuContent>
+                            <ContextMenuItem
+                              onClick={() =>
+                                navigate(fileHref, { openInNewPane: true })
+                              }
+                            >
+                              <Columns className="mr-2 size-3.5" />
+                              Open in new pane
+                            </ContextMenuItem>
+                            <ContextMenuItem
+                              onClick={() =>
+                                navigate(fileHref, { openInNewTab: true })
+                              }
+                            >
+                              <Plus className="mr-2 size-3.5" />
+                              Open in new tab
+                            </ContextMenuItem>
+                          </ContextMenuContent>
+                        ) : null}
+                      </ContextMenu>
+                    </SidebarMenuItem>
+                  );
+                })}
               </SidebarMenu>
             </SidebarGroupContent>
           </>
@@ -1334,27 +1453,54 @@ export function FilesSidebarPanel({
           ) : (
             <SidebarMenu>
               <SidebarMenuItem>
-                <SidebarMenuButton
-                  draggable
-                  onClick={(event) => {
-                    if (handlePaneIntent(event, "/workspace/files" as Route)) {
-                      return;
-                    }
-                    navigateToFilesRoot().catch(() => undefined);
-                  }}
-                  onContextMenu={(event) => {
-                    handlePaneIntent(event, "/workspace/files" as Route);
-                  }}
-                  onDragStart={(event) => {
-                    setWorkspacePaneDragData(
-                      event.dataTransfer,
-                      "/workspace/files" as Route
-                    );
-                  }}
-                >
-                  <Files className="size-4" />
-                  <span>Workspace</span>
-                </SidebarMenuButton>
+                <ContextMenu>
+                  <ContextMenuTrigger
+                    render={<div className="contents" />}
+                  >
+                    <SidebarMenuButton
+                      draggable
+                      onClick={(event) => {
+                        if (
+                          handlePaneIntent(event, "/workspace/files" as Route)
+                        ) {
+                          return;
+                        }
+                        navigateToFilesRoot().catch(() => undefined);
+                      }}
+                      onDragStart={(event) => {
+                        setWorkspacePaneDragData(
+                          event.dataTransfer,
+                          "/workspace/files" as Route
+                        );
+                      }}
+                    >
+                      <Files className="size-4" />
+                      <span>Workspace</span>
+                    </SidebarMenuButton>
+                  </ContextMenuTrigger>
+                  <ContextMenuContent>
+                    <ContextMenuItem
+                      onClick={() =>
+                        navigate("/workspace/files" as Route, {
+                          openInNewPane: true,
+                        })
+                      }
+                    >
+                      <Columns className="mr-2 size-3.5" />
+                      Open in new pane
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      onClick={() =>
+                        navigate("/workspace/files" as Route, {
+                          openInNewTab: true,
+                        })
+                      }
+                    >
+                      <Plus className="mr-2 size-3.5" />
+                      Open in new tab
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
               </SidebarMenuItem>
             </SidebarMenu>
           )}

--- a/apps/web/src/components/dashboard/workspace-pane-renderer.tsx
+++ b/apps/web/src/components/dashboard/workspace-pane-renderer.tsx
@@ -4,6 +4,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@avenire/ui/components/context-menu";
 import {
@@ -13,6 +14,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@avenire/ui/components/dropdown-menu";
+import { Input } from "@avenire/ui/components/input";
 import { cn } from "@avenire/ui/lib/utils";
 import {
   DndContext,
@@ -29,6 +31,7 @@ import {
   ArrowsSplit,
   Columns,
   DotsThree as MoreHorizontal,
+  Pencil,
   Plus,
   X,
 } from "@phosphor-icons/react";
@@ -64,6 +67,147 @@ import { useWorkspacePaneStore } from "@/stores/workspacePaneStore";
 
 const COMPACT_PANE_WIDTH = 900;
 const MIN_PANE_SIZE = 20;
+
+function TabItem({
+  editingTabTitle,
+  isEditing,
+  isActive,
+  onCancelEdit,
+  onCloseTab,
+  onEditingTitleChange,
+  onFinishEdit,
+  onOpenTab,
+  onStartEdit,
+  onSwitchTab,
+  tab,
+  tabIndex,
+  tabsLength,
+}: {
+  editingTabTitle: string;
+  isEditing: boolean;
+  isActive: boolean;
+  onCancelEdit: () => void;
+  onCloseTab: (tabId: string) => void;
+  onEditingTitleChange: (value: string) => void;
+  onFinishEdit: (tabId: string, title: string) => void;
+  onOpenTab: () => void;
+  onStartEdit: (tabId: string, title: string) => void;
+  onSwitchTab: (tabId: string) => void;
+  tab: { id: string; title: string };
+  tabIndex: number;
+  tabsLength: number;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `tab-item-${tab.id}`,
+    data: { tabId: tab.id },
+    disabled: tabsLength <= 1,
+  });
+  const { isOver, setNodeRef: setDroppableRef } = useDroppable({
+    id: `tab-drop-${tab.id}`,
+    data: { tabId: tab.id },
+    disabled: tabsLength <= 1,
+  });
+
+  const setRef = (node: HTMLDivElement | null) => {
+    setNodeRef(node);
+    setDroppableRef(node);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="flex h-6 min-w-0 max-w-56 items-center rounded-md border border-border bg-muted px-1">
+        <form
+          className="flex-1"
+          onSubmit={(e) => {
+            e.preventDefault();
+            onFinishEdit(tab.id, editingTabTitle);
+          }}
+        >
+          <Input
+            autoFocus
+            className="h-5 px-1 py-0 text-xs"
+            value={editingTabTitle}
+            onChange={(e) => onEditingTitleChange(e.target.value)}
+            onBlur={() => onFinishEdit(tab.id, editingTabTitle)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                onCancelEdit();
+              }
+            }}
+          />
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger render={<div className="contents" />}>
+        <div
+          ref={setRef}
+          className={cn(
+            "group flex h-6 min-w-0 max-w-56 cursor-grab items-center gap-1 rounded-md border px-1.5 text-left text-xs transition-colors active:cursor-grabbing",
+            isActive
+              ? "border-border bg-muted text-foreground"
+              : "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+            isDragging && "opacity-50",
+            isOver && !isDragging && "bg-primary/10"
+          )}
+          {...attributes}
+          {...listeners}
+        >
+          <button
+            aria-selected={isActive}
+            className="min-w-0 flex-1 truncate text-left"
+            onClick={() => onSwitchTab(tab.id)}
+            role="tab"
+            type="button"
+          >
+            {tab.title}
+          </button>
+          <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+            {tabIndex + 1}
+          </span>
+          <button
+            aria-label={`Close ${tab.title} tab`}
+            className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition hover:bg-foreground/10 hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onCloseTab(tab.id);
+            }}
+            type="button"
+          >
+            <X className="size-2.5" />
+          </button>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-44 rounded-lg p-1">
+        <ContextMenuItem
+          onClick={() => onStartEdit(tab.id, tab.title)}
+        >
+          <Pencil className="mr-2 size-3.5" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => onOpenTab()}>
+          <Plus className="mr-2 size-3.5" />
+          New tab
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          className="text-destructive focus:text-destructive"
+          disabled={tabsLength <= 1}
+          onClick={() => onCloseTab(tab.id)}
+        >
+          <X className="mr-2 size-3.5" />
+          Close tab
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
 
 function WorkspacePaneScene({
   paneId,
@@ -340,7 +484,9 @@ export function WorkspacePaneRenderer() {
   const focusPane = useWorkspacePaneStore((state) => state.focusPane);
   const openPane = useWorkspacePaneStore((state) => state.openPane);
   const openTab = useWorkspacePaneStore((state) => state.openTab);
+  const renameTab = useWorkspacePaneStore((state) => state.renameTab);
   const reorderPanes = useWorkspacePaneStore((state) => state.reorderPanes);
+  const reorderTabs = useWorkspacePaneStore((state) => state.reorderTabs);
   const setPaneSizes = useWorkspacePaneStore((state) => state.setPaneSizes);
   const switchTab = useWorkspacePaneStore((state) => state.switchTab);
   const syncActivePaneFromBrowser = useWorkspacePaneStore(
@@ -529,6 +675,19 @@ export function WorkspacePaneRenderer() {
     }
   };
 
+  const [editingTabId, setEditingTabId] = useState<string | null>(null);
+  const [editingTabTitle, setEditingTabTitle] = useState("");
+
+  const handleTabDragEnd = (event: DragEndEvent) => {
+    const extractTabId = (id: string) =>
+      id.replace("tab-item-", "").replace("tab-drop-", "");
+    const activeTabId = extractTabId(String(event.active.id));
+    const overTabId = event.over ? extractTabId(String(event.over.id)) : null;
+    if (overTabId && activeTabId !== overTabId) {
+      reorderTabs(activeTabId, overTabId);
+    }
+  };
+
   const handlePaneDragCancel = () => {
     setDragPreview(null);
   };
@@ -543,79 +702,50 @@ export function WorkspacePaneRenderer() {
     >
       <div className="flex h-full min-h-0 w-full flex-col bg-background">
         {tabs.length > 1 ? (
-          <div className="flex h-10 shrink-0 items-center gap-1 border-border/70 border-b bg-background px-2">
-            <div
-              aria-label="Workspace tabs"
-              className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
-              role="tablist"
-            >
-              {tabs.map((tab, tabIndex) => {
-                const isActive = tab.id === activeTabId;
-
-                return (
-                  <ContextMenu key={tab.id}>
-                    <ContextMenuTrigger
-                      render={
-                        <div
-                          className={cn(
-                            "group flex h-8 min-w-0 max-w-44 items-center gap-1 rounded-md border px-2 text-left text-sm transition-colors",
-                            isActive
-                              ? "border-border bg-muted text-foreground"
-                              : "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-                          )}
-                        />
-                      }
-                    >
-                      <button
-                        aria-selected={isActive}
-                        className="min-w-0 flex-1 truncate text-left"
-                        onClick={() => switchTab(tab.id)}
-                        role="tab"
-                        type="button"
-                      >
-                        {tab.title}
-                      </button>
-                      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
-                        {tabIndex + 1}
-                      </span>
-                      <button
-                        aria-label={`Close ${tab.title} tab`}
-                        className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition hover:bg-foreground/10 hover:text-foreground group-hover:opacity-100 focus:opacity-100"
-                        onClick={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          closeTab(tab.id);
-                        }}
-                        type="button"
-                      >
-                        <X className="size-3" />
-                      </button>
-                    </ContextMenuTrigger>
-                    <ContextMenuContent className="w-44 rounded-lg p-1">
-                      <ContextMenuItem onClick={() => openTab()}>
-                        <Plus className="mr-2 size-4" />
-                        New tab
-                      </ContextMenuItem>
-                      <ContextMenuItem
-                        className="text-destructive focus:text-destructive"
-                        disabled={tabs.length <= 1}
-                        onClick={() => closeTab(tab.id)}
-                      >
-                        <X className="mr-2 size-4" />
-                        Close tab
-                      </ContextMenuItem>
-                    </ContextMenuContent>
-                  </ContextMenu>
-                );
-              })}
-            </div>
+          <div className="flex h-9 shrink-0 items-center gap-1 border-border/70 border-b bg-background px-1.5">
+            <DndContext onDragEnd={handleTabDragEnd} sensors={sensors}>
+              <div
+                aria-label="Workspace tabs"
+                className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+                role="tablist"
+              >
+                {tabs.map((tab, tabIndex) => (
+                  <TabItem
+                    editingTabTitle={editingTabTitle}
+                    isActive={tab.id === activeTabId}
+                    isEditing={editingTabId === tab.id}
+                    key={tab.id}
+                    onCancelEdit={() => {
+                      setEditingTabId(null);
+                      setEditingTabTitle("");
+                    }}
+                    onCloseTab={closeTab}
+                    onEditingTitleChange={setEditingTabTitle}
+                    onFinishEdit={(tabId, title) => {
+                      renameTab(tabId, title);
+                      setEditingTabId(null);
+                      setEditingTabTitle("");
+                    }}
+                    onOpenTab={openTab}
+                    onStartEdit={(tabId, title) => {
+                      setEditingTabId(tabId);
+                      setEditingTabTitle(title);
+                    }}
+                    onSwitchTab={switchTab}
+                    tab={tab}
+                    tabIndex={tabIndex}
+                    tabsLength={tabs.length}
+                  />
+                ))}
+              </div>
+            </DndContext>
             <button
               aria-label="New workspace tab"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted/70 hover:text-foreground"
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted/70 hover:text-foreground"
               onClick={() => openTab()}
               type="button"
             >
-              <Plus className="size-4" />
+              <Plus className="size-3.5" />
             </button>
           </div>
         ) : null}

--- a/apps/web/src/components/dashboard/workspace-pane-renderer.tsx
+++ b/apps/web/src/components/dashboard/workspace-pane-renderer.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@avenire/ui/components/context-menu";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -23,6 +29,7 @@ import {
   ArrowsSplit,
   Columns,
   DotsThree as MoreHorizontal,
+  Plus,
   X,
 } from "@phosphor-icons/react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -156,6 +163,7 @@ function WorkspacePaneSurface({
   isMultiPane,
   onClose,
   onFocus,
+  onOpenTab,
   onSplitHorizontal,
   pane,
 }: {
@@ -164,6 +172,7 @@ function WorkspacePaneSurface({
   isMultiPane: boolean;
   onClose: () => void;
   onFocus: () => void;
+  onOpenTab: () => void;
   onSplitHorizontal: () => void;
   pane: {
     id: string;
@@ -234,6 +243,10 @@ function WorkspacePaneSurface({
         <DropdownMenuItem onClick={onSplitHorizontal}>
           <Columns className="mr-2 size-4" />
           Split right
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onOpenTab}>
+          <Plus className="mr-2 size-4" />
+          Open in new tab
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
@@ -318,17 +331,22 @@ export function WorkspacePaneRenderer() {
   const { workspace } = useWorkspaceBootstrap();
   const panes = useWorkspacePaneStore((state) => state.panes);
   const activePaneId = useWorkspacePaneStore((state) => state.activePaneId);
+  const activeTabId = useWorkspacePaneStore((state) => state.activeTabId);
   const ensureInitialized = useWorkspacePaneStore(
     (state) => state.ensureInitialized
   );
   const closePane = useWorkspacePaneStore((state) => state.closePane);
+  const closeTab = useWorkspacePaneStore((state) => state.closeTab);
   const focusPane = useWorkspacePaneStore((state) => state.focusPane);
   const openPane = useWorkspacePaneStore((state) => state.openPane);
+  const openTab = useWorkspacePaneStore((state) => state.openTab);
   const reorderPanes = useWorkspacePaneStore((state) => state.reorderPanes);
   const setPaneSizes = useWorkspacePaneStore((state) => state.setPaneSizes);
+  const switchTab = useWorkspacePaneStore((state) => state.switchTab);
   const syncActivePaneFromBrowser = useWorkspacePaneStore(
     (state) => state.syncActivePaneFromBrowser
   );
+  const tabs = useWorkspacePaneStore((state) => state.tabs);
   const setActiveHeaderPaneId = useHeaderStore(
     (state) => state.setActivePaneId
   );
@@ -422,6 +440,37 @@ export function WorkspacePaneRenderer() {
     setActiveHeaderPaneId(activePaneId);
   }, [activePaneId, setActiveHeaderPaneId]);
 
+  useEffect(() => {
+    if (isMobile || !paneStoreHydrated) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        !(
+          event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey
+        )
+      ) {
+        return;
+      }
+
+      const tabIndex = Number(event.key) - 1;
+      const tab = tabs[tabIndex];
+      if (!tab || tabIndex < 0 || tabIndex > 8) {
+        return;
+      }
+
+      event.preventDefault();
+      switchTab(tab.id);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isMobile, paneStoreHydrated, switchTab, tabs]);
+
   if (!workspace || panes.length === 0) {
     return <WorkspaceRoutePlaceholder label="Loading workspace..." />;
   }
@@ -492,10 +541,87 @@ export function WorkspacePaneRenderer() {
       onDragStart={handlePaneDragStart}
       sensors={sensors}
     >
-      <div className="h-full min-h-0 w-full bg-background">
+      <div className="flex h-full min-h-0 w-full flex-col bg-background">
+        {tabs.length > 1 ? (
+          <div className="flex h-10 shrink-0 items-center gap-1 border-border/70 border-b bg-background px-2">
+            <div
+              aria-label="Workspace tabs"
+              className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+              role="tablist"
+            >
+              {tabs.map((tab, tabIndex) => {
+                const isActive = tab.id === activeTabId;
+
+                return (
+                  <ContextMenu key={tab.id}>
+                    <ContextMenuTrigger
+                      render={
+                        <div
+                          className={cn(
+                            "group flex h-8 min-w-0 max-w-44 items-center gap-1 rounded-md border px-2 text-left text-sm transition-colors",
+                            isActive
+                              ? "border-border bg-muted text-foreground"
+                              : "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                          )}
+                        />
+                      }
+                    >
+                      <button
+                        aria-selected={isActive}
+                        className="min-w-0 flex-1 truncate text-left"
+                        onClick={() => switchTab(tab.id)}
+                        role="tab"
+                        type="button"
+                      >
+                        {tab.title}
+                      </button>
+                      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                        {tabIndex + 1}
+                      </span>
+                      <button
+                        aria-label={`Close ${tab.title} tab`}
+                        className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition hover:bg-foreground/10 hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          closeTab(tab.id);
+                        }}
+                        type="button"
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </ContextMenuTrigger>
+                    <ContextMenuContent className="w-44 rounded-lg p-1">
+                      <ContextMenuItem onClick={() => openTab()}>
+                        <Plus className="mr-2 size-4" />
+                        New tab
+                      </ContextMenuItem>
+                      <ContextMenuItem
+                        className="text-destructive focus:text-destructive"
+                        disabled={tabs.length <= 1}
+                        onClick={() => closeTab(tab.id)}
+                      >
+                        <X className="mr-2 size-4" />
+                        Close tab
+                      </ContextMenuItem>
+                    </ContextMenuContent>
+                  </ContextMenu>
+                );
+              })}
+            </div>
+            <button
+              aria-label="New workspace tab"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted/70 hover:text-foreground"
+              onClick={() => openTab()}
+              type="button"
+            >
+              <Plus className="size-4" />
+            </button>
+          </div>
+        ) : null}
         <PanelGroup
           autoSaveId="avenire-workspace-panes"
-          className="h-full min-h-0 min-w-0"
+          className="min-h-0 min-w-0 flex-1"
           direction="horizontal"
           onLayout={(sizes) => {
             if (rowId) {
@@ -541,6 +667,9 @@ export function WorkspacePaneRenderer() {
                     isMultiPane={isMultiPane}
                     onClose={() => closePane(pane.id)}
                     onFocus={() => focusPane(pane.id)}
+                    onOpenTab={() =>
+                      openTab(`${pane.route.pathname}${pane.route.search}`)
+                    }
                     onSplitHorizontal={() =>
                       openPane("/workspace", {
                         sourcePaneId: pane.id,

--- a/apps/web/src/components/files/explorer.tsx
+++ b/apps/web/src/components/files/explorer.tsx
@@ -1626,6 +1626,7 @@ export function FileExplorer({
   const { paneId } = useCurrentWorkspacePane();
   const closePane = useWorkspacePaneStore((state) => state.closePane);
   const openPane = useWorkspacePaneStore((state) => state.openPane);
+  const openTab = useWorkspacePaneStore((state) => state.openTab);
   const paneCount = useWorkspacePaneStore((state) => state.panes.length);
   const currentUser = useUserStore((state) => state.user);
   const _setSettingsOpen = useDashboardOverlayStore(
@@ -5608,6 +5609,10 @@ export function FileExplorer({
               <Columns className="size-3.5" />
               Split right
             </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => openTab()}>
+              <Plus className="size-3.5" />
+              Open in new tab
+            </DropdownMenuItem>
             <DropdownMenuItem
               disabled={!canClosePane}
               onClick={() => closePane(paneId)}
@@ -5681,6 +5686,7 @@ export function FileExplorer({
     setHeaderContext,
     toggleCurrentPinnedItem,
     openPane,
+    openTab,
     paneId,
     workspaceUuid,
   ]);

--- a/apps/web/src/components/files/explorer/file-preview-panel.tsx
+++ b/apps/web/src/components/files/explorer/file-preview-panel.tsx
@@ -1127,7 +1127,7 @@ export function FilePreviewPanel({
                 }}
               >
                 <Plus className="size-3.5" />
-                Open in new tab
+                Open in workspace tab
               </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={!canClosePane}

--- a/apps/web/src/components/files/explorer/file-preview-panel.tsx
+++ b/apps/web/src/components/files/explorer/file-preview-panel.tsx
@@ -39,6 +39,7 @@ import {
   LinkSimple,
   DotsThree as MoreHorizontal,
   Pencil,
+  Plus,
   PushPin as Pin,
   PushPinSlash as PinOff,
   ArrowCounterClockwise as RotateCcw,
@@ -325,6 +326,7 @@ export function FilePreviewPanel({
   const { paneId } = useCurrentWorkspacePane();
   const closePane = useWorkspacePaneStore((state) => state.closePane);
   const openPane = useWorkspacePaneStore((state) => state.openPane);
+  const openTab = useWorkspacePaneStore((state) => state.openTab);
   const paneCount = useWorkspacePaneStore((state) => state.panes.length);
   const canClosePane = paneCount > 1;
 
@@ -1116,6 +1118,18 @@ export function FilePreviewPanel({
                 Split right
               </DropdownMenuItem>
               <DropdownMenuItem
+                onClick={() => {
+                  const params = new URLSearchParams();
+                  params.set("file", activeFile.id);
+                  openTab(
+                    `/workspace/files/${workspaceUuid}/folder/${activeFile.folderId}?${params.toString()}`
+                  );
+                }}
+              >
+                <Plus className="size-3.5" />
+                Open in new tab
+              </DropdownMenuItem>
+              <DropdownMenuItem
                 disabled={!canClosePane}
                 onClick={() => closePane(paneId)}
               >
@@ -1195,6 +1209,7 @@ export function FilePreviewPanel({
     triggerNoteBannerPicker,
     toggleCurrentPinnedItem,
     openPane,
+    openTab,
     paneId,
     workspaceUuid,
     isImage,

--- a/apps/web/src/components/settings/settings-panel.tsx
+++ b/apps/web/src/components/settings/settings-panel.tsx
@@ -205,6 +205,9 @@ const KEYBOARD_SHORTCUT_GROUPS = [
     name: "Workspace",
     items: [
       { label: "Toggle Sidebar", keys: ["Ctrl", "B"] },
+      { label: "Open link in side pane", keys: ["Alt", "Click"] },
+      { label: "Open link in workspace tab", keys: ["Ctrl", "Click"] },
+      { label: "Switch workspace tabs", keys: ["Ctrl", "1-9"] },
       { label: "Open Model Picker", keys: ["Ctrl", "/"] },
       { label: "Show or hide pet", keys: ["Ctrl", "Shift", "Y"] },
     ],

--- a/apps/web/src/components/ui/tree-view.tsx
+++ b/apps/web/src/components/ui/tree-view.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@avenire/ui/components/context-menu";
+import {
   CaretRight as ChevronRight,
   File,
   Folder,
@@ -15,6 +20,7 @@ export interface TreeDataItem {
   actions?: ReactNode;
   children?: TreeDataItem[];
   className?: string;
+  contextMenuContent?: ReactNode;
   disabled?: boolean;
   draggable?: boolean;
   droppable?: boolean;
@@ -256,23 +262,22 @@ export function TreeView({
         item,
       });
 
-      return (
-        <div className={cn("min-w-0", item.className)} data-tree-id={item.id}>
-          <div
-            aria-expanded={hasChildren ? isExpanded : undefined}
-            className={cn(
-              "group/tree-row flex w-full min-w-0 items-center gap-2 rounded-xl px-2 py-1.5 transition-colors",
-              "hover:bg-primary/6",
-              isSelected && "bg-primary/10 text-primary ring-1 ring-primary/20",
-              isDropTarget && "bg-primary/12 ring-1 ring-primary/30",
-              item.disabled && "pointer-events-none opacity-50"
-            )}
-            draggable={item.draggable}
-            onClick={() => handleSelect(item)}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              item.onContextMenu?.();
-            }}
+      const row = (
+        <div
+          aria-expanded={hasChildren ? isExpanded : undefined}
+          className={cn(
+            "group/tree-row flex w-full min-w-0 items-center gap-2 rounded-xl px-2 py-1.5 transition-colors",
+            "hover:bg-primary/6",
+            isSelected && "bg-primary/10 text-primary ring-1 ring-primary/20",
+            isDropTarget && "bg-primary/12 ring-1 ring-primary/30",
+            item.disabled && "pointer-events-none opacity-50"
+          )}
+          draggable={item.draggable}
+          onClick={() => handleSelect(item)}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            item.onContextMenu?.();
+          }}
             onDragEnd={() => {
               setDraggedItemId(null);
               setDropTargetItemId(null);
@@ -354,6 +359,22 @@ export function TreeView({
               </div>
             ) : null}
           </div>
+      );
+
+      const wrappedRow = item.contextMenuContent ? (
+        <ContextMenu key={item.id}>
+          <ContextMenuTrigger render={<div className="contents" />}>
+            {row}
+          </ContextMenuTrigger>
+          <ContextMenuContent>{item.contextMenuContent}</ContextMenuContent>
+        </ContextMenu>
+      ) : (
+        row
+      );
+
+      return (
+        <div className={cn("min-w-0", item.className)} data-tree-id={item.id}>
+          {wrappedRow}
         </div>
       );
     },

--- a/apps/web/src/lib/workspace-panes.tsx
+++ b/apps/web/src/lib/workspace-panes.tsx
@@ -115,13 +115,24 @@ function navigatePane(
   router: AppRouterInstance,
   pane: WorkspacePaneContextValue,
   href: string,
-  options?: { openInNewPane?: boolean; replace?: boolean; scroll?: boolean }
+  options?: {
+    openInNewPane?: boolean;
+    openInNewTab?: boolean;
+    replace?: boolean;
+    scroll?: boolean;
+  }
 ) {
   const openInNewPane = options?.openInNewPane ?? false;
+  const openInNewTab = options?.openInNewTab ?? false;
   const replace = options?.replace ?? false;
   const scroll = options?.scroll ?? false;
   const route = buildRouteState(href);
   const store = useWorkspacePaneStore.getState();
+
+  if (openInNewTab) {
+    store.openTab(`${route.pathname}${route.search}`);
+    return;
+  }
 
   if (openInNewPane) {
     store.openPane(`${route.pathname}${route.search}`, {
@@ -225,12 +236,15 @@ export function useWorkspacePaneNavigation() {
         href: string,
         options?: {
           openInNewPane?: boolean;
+          openInNewTab?: boolean;
           replace?: boolean;
           scroll?: boolean;
         }
       ) => navigatePane(router, pane, href, options),
       openInNewPane: (href: string) =>
         navigatePane(router, pane, href, { openInNewPane: true }),
+      openInNewTab: (href: string) =>
+        navigatePane(router, pane, href, { openInNewTab: true }),
     }),
     [pane, router]
   );
@@ -252,14 +266,23 @@ export function useWorkspaceSurfaceNavigation(options?: {
         href: string,
         navigateOptions?: {
           openInNewPane?: boolean;
+          openInNewTab?: boolean;
           replace?: boolean;
           scroll?: boolean;
         }
       ) => {
         const route = buildRouteState(href);
         const openInNewPane = navigateOptions?.openInNewPane ?? false;
+        const openInNewTab = navigateOptions?.openInNewTab ?? false;
         const replace = navigateOptions?.replace ?? false;
         const scroll = navigateOptions?.scroll ?? false;
+
+        if (panesEnabled && openInNewTab) {
+          useWorkspacePaneStore
+            .getState()
+            .openTab(`${route.pathname}${route.search}`);
+          return;
+        }
 
         if (panesEnabled && openInNewPane) {
           openPane(`${route.pathname}${route.search}`, {
@@ -314,7 +337,7 @@ function findNavigableAnchor(target: EventTarget | null) {
 export function WorkspacePaneInteractionBoundary({
   children,
 }: PropsWithChildren) {
-  const { navigate, openInNewPane } = useWorkspacePaneNavigation();
+  const { navigate, openInNewPane, openInNewTab } = useWorkspacePaneNavigation();
 
   const handleClickCapture = (event: MouseEvent<HTMLDivElement>) => {
     const anchor = findNavigableAnchor(event.target);
@@ -323,7 +346,13 @@ export function WorkspacePaneInteractionBoundary({
     }
 
     const href = anchor.href;
-    if (event.metaKey || event.ctrlKey || event.shiftKey) {
+    if (event.shiftKey || event.metaKey) {
+      return;
+    }
+
+    if (event.ctrlKey) {
+      event.preventDefault();
+      openInNewTab(href);
       return;
     }
 
@@ -341,16 +370,6 @@ export function WorkspacePaneInteractionBoundary({
     navigate(href);
   };
 
-  const handleContextMenuCapture = (event: MouseEvent<HTMLDivElement>) => {
-    const anchor = findNavigableAnchor(event.target);
-    if (!anchor) {
-      return;
-    }
-
-    event.preventDefault();
-    openInNewPane(anchor.href);
-  };
-
   const handleDragStartCapture = (event: DragEvent<HTMLDivElement>) => {
     const anchor = findNavigableAnchor(event.target);
     if (!anchor) {
@@ -364,7 +383,6 @@ export function WorkspacePaneInteractionBoundary({
     <div
       className="contents"
       onClickCapture={handleClickCapture}
-      onContextMenuCapture={handleContextMenuCapture}
       onDragStartCapture={handleDragStartCapture}
     >
       {children}

--- a/apps/web/src/stores/workspacePaneStore.ts
+++ b/apps/web/src/stores/workspacePaneStore.ts
@@ -13,9 +13,18 @@ interface WorkspacePaneRowRecord {
   size: number;
 }
 
+interface WorkspacePaneTabRecord {
+  activePaneId: string | null;
+  id: string;
+  panes: WorkspacePaneRecord[];
+  title: string;
+}
+
 interface WorkspacePaneStoreState {
   activePaneId: string | null;
+  activeTabId: string | null;
   closePane: (paneId: string) => void;
+  closeTab: (tabId: string) => void;
   ensureInitialized: (route: WorkspacePaneRouteState) => void;
   focusPane: (paneId: string) => void;
   initialized: boolean;
@@ -35,6 +44,7 @@ interface WorkspacePaneStoreState {
       splitPlacement?: "after" | "before";
     }
   ) => void;
+  openTab: (href?: string) => void;
   panes: WorkspacePaneRecord[];
   reorderPanes: (draggedPaneId: string, targetPaneId: string) => void;
   rows: WorkspacePaneRowRecord[];
@@ -45,10 +55,12 @@ interface WorkspacePaneStoreState {
   ) => void;
   setPaneSizes: (rowId: string, sizes: number[]) => void;
   setRowSizes: (sizes: number[]) => void;
+  switchTab: (tabId: string) => void;
   syncActivePaneFromBrowser: (route: WorkspacePaneRouteState) => void;
+  tabs: WorkspacePaneTabRecord[];
 }
 
-const STORAGE_KEY = "workspace-pane-layout-v4";
+const STORAGE_KEY = "workspace-pane-layout-v5";
 const DEFAULT_ROW_ID = "workspace-row";
 
 function createPaneId() {
@@ -64,6 +76,25 @@ function buildRoute(href: string): WorkspacePaneRouteState {
     pathname: pathname || "/workspace",
     search: search ? `?${search}` : "",
   };
+}
+
+function titleForRoute(route: WorkspacePaneRouteState) {
+  if (route.pathname === "/workspace") {
+    return "Home";
+  }
+  if (route.pathname === "/workspace/tasks") {
+    return "Tasks";
+  }
+  if (route.pathname.startsWith("/workspace/chats")) {
+    return "Chats";
+  }
+  if (route.pathname.startsWith("/workspace/flashcards")) {
+    return "Flashcards";
+  }
+  if (route.pathname.startsWith("/workspace/files")) {
+    return "Files";
+  }
+  return "Workspace";
 }
 
 function normalizeSizes<T extends { size: number }>(items: T[]) {
@@ -116,6 +147,79 @@ function sanitizeState(state: {
   };
 }
 
+function createTab(route: WorkspacePaneRouteState): WorkspacePaneTabRecord {
+  const paneId = createPaneId();
+  return {
+    activePaneId: paneId,
+    id: createPaneId(),
+    panes: [{ id: paneId, route, rowId: DEFAULT_ROW_ID, size: 100 }],
+    title: titleForRoute(route),
+  };
+}
+
+function sanitizeTab(tab: WorkspacePaneTabRecord): WorkspacePaneTabRecord | null {
+  const panes = sanitizePanes(tab.panes);
+  if (panes.length === 0) {
+    return null;
+  }
+
+  const activePaneId = panes.some((pane) => pane.id === tab.activePaneId)
+    ? tab.activePaneId
+    : (panes[0]?.id ?? null);
+  const activePane = panes.find((pane) => pane.id === activePaneId) ?? panes[0];
+
+  return {
+    activePaneId,
+    id: tab.id || createPaneId(),
+    panes,
+    title: tab.title || (activePane ? titleForRoute(activePane.route) : "Workspace"),
+  };
+}
+
+function activeTabFromState(state: WorkspacePaneStoreState) {
+  return (
+    state.tabs.find((tab) => tab.id === state.activeTabId) ??
+    state.tabs[0] ??
+    null
+  );
+}
+
+function rowsForPanes(panes: WorkspacePaneRecord[]) {
+  return panes.length > 0 ? [{ id: DEFAULT_ROW_ID, size: 100 }] : [];
+}
+
+function mirrorActiveTab(state: WorkspacePaneStoreState) {
+  const activeTab = activeTabFromState(state);
+  return {
+    activePaneId: activeTab?.activePaneId ?? null,
+    activeTabId: activeTab?.id ?? null,
+    panes: activeTab?.panes ?? [],
+    rows: rowsForPanes(activeTab?.panes ?? []),
+  };
+}
+
+function updateActiveTab(
+  state: WorkspacePaneStoreState,
+  update: (tab: WorkspacePaneTabRecord) => WorkspacePaneTabRecord
+) {
+  const activeTab = activeTabFromState(state);
+  if (!activeTab) {
+    return state;
+  }
+
+  const nextTab = sanitizeTab(update(activeTab));
+  if (!nextTab) {
+    return state;
+  }
+
+  const tabs = state.tabs.map((tab) => (tab.id === activeTab.id ? nextTab : tab));
+  return {
+    tabs,
+    initialized: true,
+    ...mirrorActiveTab({ ...state, tabs, activeTabId: nextTab.id }),
+  };
+}
+
 function insertPane(
   panes: WorkspacePaneRecord[],
   pane: WorkspacePaneRecord,
@@ -156,29 +260,36 @@ export const useWorkspacePaneStore = create<WorkspacePaneStoreState>()(
   persist(
     (set) => ({
       activePaneId: null,
+      activeTabId: null,
       initialized: false,
       panes: [],
       rows: [],
+      tabs: [],
       ensureInitialized: (route) =>
         set((state) => {
-          if (state.initialized && state.panes.length > 0) {
+          if (state.initialized && state.tabs.length > 0) {
             return state;
           }
 
-          const paneId = createPaneId();
+          const tab = createTab(route);
           return {
-            activePaneId: paneId,
+            activePaneId: tab.activePaneId,
+            activeTabId: tab.id,
             initialized: true,
-            panes: [{ id: paneId, route, rowId: DEFAULT_ROW_ID, size: 100 }],
+            panes: tab.panes,
             rows: [{ id: DEFAULT_ROW_ID, size: 100 }],
+            tabs: [tab],
           };
         }),
       focusPane: (paneId) =>
-        set((state) =>
-          state.panes.some((pane) => pane.id === paneId)
-            ? { activePaneId: paneId }
-            : state
-        ),
+        set((state) => {
+          const activeTab = activeTabFromState(state);
+          if (!activeTab?.panes.some((pane) => pane.id === paneId)) {
+            return state;
+          }
+
+          return updateActiveTab(state, (tab) => ({ ...tab, activePaneId: paneId }));
+        }),
       openPane: (href, options) =>
         set((state) => {
           const pane: WorkspacePaneRecord = {
@@ -188,58 +299,119 @@ export const useWorkspacePaneStore = create<WorkspacePaneStoreState>()(
             size: 100,
           };
 
-          return sanitizeState({
-            activePaneId: pane.id,
-            initialized: true,
-            panes: insertPane(
-              state.panes,
-              pane,
-              options?.sourcePaneId ?? state.activePaneId ?? undefined,
-              options?.splitPlacement ?? "after"
-            ),
+          return updateActiveTab(state, (tab) => {
+            const next = sanitizeState({
+              activePaneId: pane.id,
+              initialized: true,
+              panes: insertPane(
+                tab.panes,
+                pane,
+                options?.sourcePaneId ?? tab.activePaneId ?? undefined,
+                options?.splitPlacement ?? "after"
+              ),
+            });
+            return {
+              ...tab,
+              activePaneId: next.activePaneId,
+              panes: next.panes,
+              title: titleForRoute(pane.route),
+            };
           });
+        }),
+      openTab: (href) =>
+        set((state) => {
+          const activeTab = activeTabFromState(state);
+          const activePane = activeTab?.panes.find(
+            (pane) => pane.id === activeTab.activePaneId
+          );
+          const route = href
+            ? buildRoute(href)
+            : (activePane?.route ?? buildRoute("/workspace"));
+          const tab = createTab(route);
+          const tabs = [...state.tabs, tab];
+
+          return {
+            activePaneId: tab.activePaneId,
+            activeTabId: tab.id,
+            initialized: true,
+            panes: tab.panes,
+            rows: rowsForPanes(tab.panes),
+            tabs,
+          };
         }),
       movePaneToSplit: (draggedPaneId, targetPaneId, options) =>
         set((state) => {
-          const draggedPane = state.panes.find(
+          const activeTab = activeTabFromState(state);
+          if (!activeTab) {
+            return state;
+          }
+
+          const draggedPane = activeTab.panes.find(
             (pane) => pane.id === draggedPaneId
           );
           if (!draggedPane || draggedPaneId === targetPaneId) {
             return state;
           }
 
-          const withoutDragged = state.panes.filter(
+          const withoutDragged = activeTab.panes.filter(
             (pane) => pane.id !== draggedPaneId
           );
-          return sanitizeState({
-            activePaneId: draggedPaneId,
-            initialized: true,
-            panes: insertPane(
-              withoutDragged,
-              draggedPane,
-              targetPaneId,
-              options.splitPlacement ?? "after"
-            ),
+          return updateActiveTab(state, (tab) => {
+            const next = sanitizeState({
+              activePaneId: draggedPaneId,
+              initialized: true,
+              panes: insertPane(
+                withoutDragged,
+                draggedPane,
+                targetPaneId,
+                options.splitPlacement ?? "after"
+              ),
+            });
+            return { ...tab, activePaneId: next.activePaneId, panes: next.panes };
           });
         }),
       closePane: (paneId) =>
         set((state) => {
+          const activeTab = activeTabFromState(state);
           if (
-            state.panes.length <= 1 ||
-            !state.panes.some((pane) => pane.id === paneId)
+            !activeTab ||
+            activeTab.panes.length <= 1 ||
+            !activeTab.panes.some((pane) => pane.id === paneId)
           ) {
             return state;
           }
 
-          return sanitizeState({
-            activePaneId: chooseActiveAfterClose(
-              state.panes,
-              paneId,
-              state.activePaneId
-            ),
-            initialized: true,
-            panes: state.panes.filter((pane) => pane.id !== paneId),
+          return updateActiveTab(state, (tab) => {
+            const next = sanitizeState({
+              activePaneId: chooseActiveAfterClose(
+                tab.panes,
+                paneId,
+                tab.activePaneId
+              ),
+              initialized: true,
+              panes: tab.panes.filter((pane) => pane.id !== paneId),
+            });
+            return { ...tab, activePaneId: next.activePaneId, panes: next.panes };
           });
+        }),
+      closeTab: (tabId) =>
+        set((state) => {
+          if (state.tabs.length <= 1 || !state.tabs.some((tab) => tab.id === tabId)) {
+            return state;
+          }
+
+          const closedIndex = state.tabs.findIndex((tab) => tab.id === tabId);
+          const tabs = state.tabs.filter((tab) => tab.id !== tabId);
+          const nextActiveTabId =
+            state.activeTabId === tabId
+              ? (tabs[closedIndex]?.id ?? tabs[closedIndex - 1]?.id ?? tabs[0]?.id ?? null)
+              : state.activeTabId;
+
+          return {
+            initialized: true,
+            tabs,
+            ...mirrorActiveTab({ ...state, tabs, activeTabId: nextActiveTabId }),
+          };
         }),
       reorderPanes: (draggedPaneId, targetPaneId) =>
         set((state) => {
@@ -247,92 +419,150 @@ export const useWorkspacePaneStore = create<WorkspacePaneStoreState>()(
             return state;
           }
 
-          const draggedIndex = state.panes.findIndex(
+          const activeTab = activeTabFromState(state);
+          if (!activeTab) {
+            return state;
+          }
+
+          const draggedIndex = activeTab.panes.findIndex(
             (pane) => pane.id === draggedPaneId
           );
-          const targetIndex = state.panes.findIndex(
+          const targetIndex = activeTab.panes.findIndex(
             (pane) => pane.id === targetPaneId
           );
-          const draggedPane = state.panes[draggedIndex];
+          const draggedPane = activeTab.panes[draggedIndex];
           if (!(draggedPane && targetIndex >= 0)) {
             return state;
           }
 
-          const withoutDragged = state.panes.filter(
+          const withoutDragged = activeTab.panes.filter(
             (pane) => pane.id !== draggedPaneId
           );
-          return sanitizeState({
-            activePaneId: draggedPaneId,
-            initialized: true,
-            panes: insertPane(
-              withoutDragged,
-              draggedPane,
-              targetPaneId,
-              draggedIndex < targetIndex ? "after" : "before"
-            ),
+          return updateActiveTab(state, (tab) => {
+            const next = sanitizeState({
+              activePaneId: draggedPaneId,
+              initialized: true,
+              panes: insertPane(
+                withoutDragged,
+                draggedPane,
+                targetPaneId,
+                draggedIndex < targetIndex ? "after" : "before"
+              ),
+            });
+            return { ...tab, activePaneId: next.activePaneId, panes: next.panes };
           });
         }),
       setPaneRoute: (paneId, route) =>
         set((state) => {
-          if (!state.panes.some((pane) => pane.id === paneId)) {
+          const activeTab = activeTabFromState(state);
+          if (!activeTab?.panes.some((pane) => pane.id === paneId)) {
+            return state;
+          }
+
+          return updateActiveTab(state, (tab) => ({
+            ...tab,
+            activePaneId: paneId,
+            panes: tab.panes.map((pane) =>
+              pane.id === paneId ? { ...pane, route } : pane
+            ),
+            title: titleForRoute(route),
+          }));
+        }),
+      setPaneSizes: (_rowId, sizes) =>
+        set((state) =>
+          updateActiveTab(state, (tab) => ({
+            ...tab,
+            panes: normalizeSizes(
+              tab.panes.map((pane, index) => ({
+                ...pane,
+                size: sizes[index] ?? pane.size,
+              }))
+            ),
+          }))
+        ),
+      setRowSizes: () => set((state) => state),
+      switchTab: (tabId) =>
+        set((state) => {
+          if (!state.tabs.some((tab) => tab.id === tabId)) {
             return state;
           }
 
           return {
-            activePaneId: paneId,
-            panes: state.panes.map((pane) =>
-              pane.id === paneId ? { ...pane, route } : pane
-            ),
+            initialized: true,
+            ...mirrorActiveTab({ ...state, activeTabId: tabId }),
           };
         }),
-      setPaneSizes: (_rowId, sizes) =>
-        set((state) => ({
-          panes: normalizeSizes(
-            state.panes.map((pane, index) => ({
-              ...pane,
-              size: sizes[index] ?? pane.size,
-            }))
-          ),
-        })),
-      setRowSizes: () => set((state) => state),
       syncActivePaneFromBrowser: (route) =>
         set((state) => {
-          const activePaneId = state.activePaneId ?? state.panes[0]?.id ?? null;
+          const activeTab = activeTabFromState(state);
+          if (!activeTab) {
+            return state;
+          }
+
+          const activePaneId =
+            activeTab.activePaneId ?? activeTab.panes[0]?.id ?? null;
           if (!activePaneId) {
             return state;
           }
 
-          return {
+          return updateActiveTab(state, (tab) => ({
+            ...tab,
             activePaneId,
-            panes: state.panes.map((pane) =>
+            panes: tab.panes.map((pane) =>
               pane.id === activePaneId ? { ...pane, route } : pane
             ),
-          };
+            title: titleForRoute(route),
+          }));
         }),
     }),
     {
       name: STORAGE_KEY,
       partialize: (state) => ({
         activePaneId: state.activePaneId,
+        activeTabId: state.activeTabId,
         initialized: state.initialized,
         panes: state.panes,
+        tabs: state.tabs,
       }),
       storage: createJSONStorage(() => localStorage),
-      merge: (persistedState, currentState) =>
-        ({
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as
+          | Partial<WorkspacePaneStoreState>
+          | undefined;
+        const sanitizedTabs = (persisted?.tabs ?? [])
+          .map((tab) => sanitizeTab(tab))
+          .filter((tab): tab is WorkspacePaneTabRecord => Boolean(tab));
+        const tabs =
+          sanitizedTabs.length > 0
+            ? sanitizedTabs
+            : sanitizeState({
+                activePaneId: persisted?.activePaneId ?? currentState.activePaneId,
+                initialized: persisted?.initialized ?? currentState.initialized,
+                panes: persisted?.panes ?? currentState.panes,
+              }).panes.length > 0
+              ? [
+                  {
+                    activePaneId:
+                      persisted?.activePaneId ?? currentState.activePaneId,
+                    id: createPaneId(),
+                    panes: sanitizePanes(
+                      persisted?.panes ?? currentState.panes
+                    ),
+                    title: "Workspace",
+                  },
+                ]
+              : [];
+        const activeTabId = tabs.some((tab) => tab.id === persisted?.activeTabId)
+          ? (persisted?.activeTabId ?? null)
+          : (tabs[0]?.id ?? null);
+
+        return {
           ...currentState,
-          ...sanitizeState({
-            activePaneId:
-              (persistedState as Partial<WorkspacePaneStoreState> | undefined)
-                ?.activePaneId ?? currentState.activePaneId,
-            initialized:
-              (persistedState as Partial<WorkspacePaneStoreState> | undefined)
-                ?.initialized ?? currentState.initialized,
-            panes:
-              (persistedState as Partial<WorkspacePaneStoreState> | undefined)
-                ?.panes ?? currentState.panes,
-          }),
-        }) as WorkspacePaneStoreState,
+          initialized: persisted?.initialized ?? tabs.length > 0,
+          tabs,
+          ...mirrorActiveTab({ ...currentState, tabs, activeTabId }),
+        } as WorkspacePaneStoreState;
+      },
     }
   )
 );

--- a/apps/web/src/stores/workspacePaneStore.ts
+++ b/apps/web/src/stores/workspacePaneStore.ts
@@ -55,6 +55,8 @@ interface WorkspacePaneStoreState {
   ) => void;
   setPaneSizes: (rowId: string, sizes: number[]) => void;
   setRowSizes: (sizes: number[]) => void;
+  renameTab: (tabId: string, title: string) => void;
+  reorderTabs: (draggedTabId: string, targetTabId: string) => void;
   switchTab: (tabId: string) => void;
   syncActivePaneFromBrowser: (route: WorkspacePaneRouteState) => void;
   tabs: WorkspacePaneTabRecord[];
@@ -467,6 +469,36 @@ export const useWorkspacePaneStore = create<WorkspacePaneStoreState>()(
             ),
             title: titleForRoute(route),
           }));
+        }),
+      renameTab: (tabId, title) =>
+        set((state) => ({
+          ...state,
+          tabs: state.tabs.map((tab) =>
+            tab.id === tabId ? { ...tab, title } : tab
+          ),
+        })),
+      reorderTabs: (draggedTabId, targetTabId) =>
+        set((state) => {
+          if (draggedTabId === targetTabId) {
+            return state;
+          }
+          const draggedIndex = state.tabs.findIndex(
+            (tab) => tab.id === draggedTabId
+          );
+          const targetIndex = state.tabs.findIndex(
+            (tab) => tab.id === targetTabId
+          );
+          if (draggedIndex === -1 || targetIndex === -1) {
+            return state;
+          }
+          const tabs = [...state.tabs];
+          const [moved] = tabs.splice(draggedIndex, 1);
+          tabs.splice(targetIndex, 0, moved);
+          return {
+            ...state,
+            tabs,
+            ...mirrorActiveTab({ ...state, tabs, activeTabId: state.activeTabId }),
+          };
         }),
       setPaneSizes: (_rowId, sizes) =>
         set((state) =>

--- a/packages/ui/src/components/expandable-tabs.tsx
+++ b/packages/ui/src/components/expandable-tabs.tsx
@@ -4,6 +4,12 @@ import * as React from "react"
 import { AnimatePresence, m } from "framer-motion"
 
 import { cn } from "../lib/utils"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "./context-menu"
 
 type ExpandableTabItem = {
   value: string
@@ -29,6 +35,7 @@ type ExpandableTabsProps = {
   allowDeselect?: boolean
   className?: string
   persistenceKey?: string
+  contextMenuContent?: (item: ExpandableTabItem) => React.ReactNode
 }
 
 const lastMountedValueByPersistenceKey = new Map<string, string | null>()
@@ -57,6 +64,7 @@ export function ExpandableTabs({
   allowDeselect = true,
   className,
   persistenceKey,
+  contextMenuContent,
 }: ExpandableTabsProps) {
   const isControlled = value !== undefined
   const [internalValue, setInternalValue] = React.useState<string | null>(
@@ -147,9 +155,8 @@ export function ExpandableTabs({
         const Icon = item.icon
         const isSelected = currentValue === item.value
 
-        return (
+        const button = (
           <m.button
-            key={item.value}
             ref={(node) => {
               tabRefs.current[index] = node
             }}
@@ -206,6 +213,24 @@ export function ExpandableTabs({
             <span className="sr-only">{item.label}</span>
           </m.button>
         )
+
+        const menuContent = contextMenuContent?.(item)
+        if (menuContent) {
+          return (
+            <ContextMenu key={item.value}>
+              <ContextMenuTrigger
+                render={<div className="contents" />}
+              >
+                {button}
+              </ContextMenuTrigger>
+              <ContextMenuContent side="bottom" align="start">
+                {menuContent}
+              </ContextMenuContent>
+            </ContextMenu>
+          )
+        }
+
+        return button
       })}
     </div>
   )


### PR DESCRIPTION
## Summary
- add persisted workspace tabs as a desktop-only layer over existing pane layouts
- route Alt+click to side panes and Ctrl+click to workspace tabs
- add desktop tab gutter with close/new/right-click actions plus Ctrl+1-9 switching
- expose Open in new tab in split menus and update shortcut settings

## Test
- pnpm --filter @avenire/web check-types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace tabs: users can now create, switch between, and close multiple tabs to organize their workspace
  * "Open in new tab" option available from file explorer and file preview panels for efficient navigation
  * Keyboard shortcuts added for tab switching and opening links in new tabs
  * Right-click context menu support for managing workspace tabs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->