### PR TITLE
refactor: replace next/image with native img and add banner fallback

### DIFF
--- a/apps/web/src/components/files/explorer.tsx
+++ b/apps/web/src/components/files/explorer.tsx
@@ -940,8 +940,8 @@ interface WebkitFileSystemDirectoryEntry extends WebkitFileSystemEntry {
   createReader: () => WebkitFileSystemDirectoryReader;
 }
 
-const DEFAULT_FOLDER_BANNER_URL =
-  "https://gtgr46laft.ufs.sh/f/7avzGFBuzbjB9vfw3D1PxUaEr7wSqNQiFgMAvYKy35DlcXb0";
+import { STATIC_ASSETS } from "@/lib/static-assets";
+const DEFAULT_FOLDER_BANNER_URL = STATIC_ASSETS.banner1;
 
 function getMutationHistoryItemKey(item: FileMutationHistoryItem) {
   return `${item.kind}:${item.id}`;
@@ -5803,6 +5803,12 @@ export function FileExplorer({
                   className="h-full w-full object-cover"
                   fetchPriority="high"
                   loading="eager"
+                  onError={(event) => {
+                    const img = event.currentTarget;
+                    if (img.dataset.fellBack) return;
+                    img.dataset.fellBack = "1";
+                    img.src = STATIC_ASSETS.banner1;
+                  }}
                   src={currentFolderBannerUrl}
                 />
                 {bannerUploadBusy ? (

--- a/apps/web/src/components/files/explorer/file-preview-panel.tsx
+++ b/apps/web/src/components/files/explorer/file-preview-panel.tsx
@@ -49,7 +49,7 @@ import {
   X,
 } from "@phosphor-icons/react";
 import dynamic from "next/dynamic";
-import Image, { type ImageLoader } from "next/image";
+
 import {
   type ChangeEvent,
   useCallback,
@@ -114,9 +114,9 @@ const PDFViewer = dynamic(() => import("@/components/files/pdf-viewer"), {
   ssr: false,
 });
 
-const DEFAULT_NOTE_COVER_URL =
-  "https://gtgr46laft.ufs.sh/f/7avzGFBuzbjB9vfw3D1PxUaEr7wSqNQiFgMAvYKy35DlcXb0";
-const passthroughImageLoader: ImageLoader = ({ src }) => src;
+import { STATIC_ASSETS } from "@/lib/static-assets";
+const DEFAULT_NOTE_COVER_URL = STATIC_ASSETS.banner1;
+
 
 function normalizeFilePageIcon(icon: string | null | undefined) {
   if (typeof icon !== "string") {
@@ -1280,16 +1280,17 @@ export function FilePreviewPanel({
                     {noteBannerUrl ? (
                       <div className="group/banner relative w-full overflow-hidden border-border/60 bg-muted/30">
                         <div className="absolute inset-0 border-border/60 sm:border-y" />
-                        <Image
+                        <img
                           alt={`${activeFile.name} cover`}
                           className="h-32 w-full object-cover sm:h-40"
-                          height={160}
-                          loader={passthroughImageLoader}
                           loading="lazy"
-                          sizes="100vw"
+                          onError={(event) => {
+                            const img = event.currentTarget;
+                            if (img.dataset.fellBack) return;
+                            img.dataset.fellBack = "1";
+                            img.src = STATIC_ASSETS.banner1;
+                          }}
                           src={noteBannerUrl}
-                          unoptimized
-                          width={1600}
                         />
                         <div className="pointer-events-none absolute top-3 right-3 opacity-0 transition-opacity duration-150 group-focus-within/banner:opacity-100 group-hover/banner:opacity-100">
                           <div className="pointer-events-auto">
@@ -1370,15 +1371,11 @@ export function FilePreviewPanel({
                                               }
                                               type="button"
                                             >
-                                              <Image
+                                              <img
                                                 alt={option.label}
                                                 className="h-full w-full object-cover"
-                                                fill
-                                                loader={passthroughImageLoader}
                                                 loading="lazy"
-                                                sizes="(max-width: 640px) 25vw, 120px"
                                                 src={option.url}
-                                                unoptimized
                                               />
                                             </button>
                                           ))}

--- a/apps/web/src/components/flashcards/dashboard.tsx
+++ b/apps/web/src/components/flashcards/dashboard.tsx
@@ -36,7 +36,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
 import type { Route } from "next";
-import Image from "next/image";
+
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import {
   HeaderActions,
@@ -542,13 +542,11 @@ export function FlashcardsDashboard({
               </Button>
             </div>
           ) : null}
-          <Image
+          <img
             alt=""
             className="h-full w-full object-cover"
-            height={192}
+            loading="lazy"
             src={STATIC_ASSETS.banner1}
-            width={720}
-            unoptimized
           />
         </div>
 

--- a/apps/web/src/components/landing/Navbar.tsx
+++ b/apps/web/src/components/landing/Navbar.tsx
@@ -13,7 +13,7 @@ import {
 } from "@avenire/ui/components/navigation-menu";
 import { List as MenuIcon, XIcon } from "@phosphor-icons/react";
 import type { Route } from "next";
-import Image from "next/image";
+
 import Link from "next/link";
 import * as React from "react";
 import { AvenireMark } from "@/components/branding/AvenireMark";
@@ -151,11 +151,10 @@ export function Navbar() {
                           render={<Link href={highlightedBlog.href} />}
                         >
                           <div className="relative mb-2 h-24 w-full overflow-hidden rounded-md border border-border/60 bg-background">
-                            <Image
+                            <img
                               alt={highlightedBlog.title}
-                              className="object-cover"
-                              fill
-                              sizes="(max-width: 768px) 100vw, 280px"
+                              className="h-full w-full object-cover"
+                              loading="lazy"
                               src={highlightedBlog.image}
                             />
                           </div>

--- a/apps/web/src/components/marketing/hero-image.tsx
+++ b/apps/web/src/components/marketing/hero-image.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useRef } from "react";
 import { Container } from "./container";
-import Image from "next/image";
 import { motion, useMotionValue, useSpring, useTransform } from "motion/react";
 import { STATIC_ASSETS } from "@/lib/static-assets";
 import { Dot } from "./common/dots";
@@ -71,14 +70,13 @@ export const HeroImage = () => {
             translateY,
           }}
         >
-          <Image
-            src={STATIC_ASSETS.avenireWorkspace}
+          <img
             alt="Avenire workspace with a paper, generated ResNet notes, and an interactive learning widget"
             className="w-full rounded-md border border-white/10 shadow-2xl shadow-black/60"
-            priority
-            width={1918}
-            height={1019}
             draggable={false}
+            fetchPriority="high"
+            loading="eager"
+            src={STATIC_ASSETS.avenireWorkspace}
           />
         </motion.div>
         <div className="absolute inset-0 z-0 m-auto h-[90%] w-[95%] rounded-lg border border-(--pattern-fg)"></div>

--- a/apps/web/src/mdx-components.tsx
+++ b/apps/web/src/mdx-components.tsx
@@ -1,5 +1,4 @@
 import type { MDXComponents } from "mdx/types";
-import Image, { type ImageProps } from "next/image";
 
 /**
  * Global MDX Components
@@ -119,15 +118,13 @@ const components: MDXComponents = {
   // Horizontal rule
   hr: () => <hr className="my-10 border-divide" />,
 
-  // Images — uses Next.js Image for optimization
+  // Images
   img: ({ alt, ...props }) => (
-    <Image
+    <img
       alt={alt ?? ""}
       className="my-8 h-auto w-full rounded-xl border border-divide"
-      height={900}
-      sizes="(max-width: 768px) 100vw, 672px"
-      width={1600}
-      {...(props as Omit<ImageProps, "alt">)}
+      loading="lazy"
+      {...props}
     />
   ),
 


### PR DESCRIPTION
## Summary

Replaces all `next/image` usage with native `<img>` tags across the codebase, and adds `onError` fallback guards so workspace folder banners and note covers gracefully degrade to `STATIC_ASSETS.banner1` when a user's custom URL is deleted, corrupted, or otherwise fails to load.

## Changes

### Remove `next/image` (4 files)
- **hero-image.tsx** — workspace screenshot uses `<img>` with `fetchPriority=high`
- **dashboard.tsx** — flashcard misconception banner uses `<img>`
- **Navbar.tsx** — blog preview thumbnail uses `<img>`
- **mdx-components.tsx** — MDX `img` override uses `<img>` instead of Next `Image`

### Remove `next/image` in file viewer (1 file)
- **file-preview-panel.tsx** — note banner and cover gallery use `<img>`; removed `passthroughImageLoader`

### Banner fallback to `STATIC_ASSETS.banner1` (2 files)
- **explorer.tsx** — folder banner `<img>` gets `onError` fallback; `DEFAULT_FOLDER_BANNER_URL` now sourced from `STATIC_ASSETS.banner1`
- **file-preview-panel.tsx** — note cover `<img>` gets `onError` fallback; `DEFAULT_NOTE_COVER_URL` now sourced from `STATIC_ASSETS.banner1`

## Why

External banner URLs can become stale or broken. Without a fallback the user sees a broken image. The `onError` guard swaps to the generic `banner1` asset so the UI stays intact.