### PR TITLE
Fix chat generation output and tool activity

### DIFF
--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -739,7 +739,7 @@ async function generateChatMetadata(
         '{"title":"...","icon":"..."}',
         `User message: ${latestUserText}`,
       ].join("\n"),
-      maxOutputTokens: 64,
+      maxOutputTokens: 256,
       temperature: 0.2,
       abortSignal,
       experimental_telemetry: telemetry,
@@ -1135,6 +1135,43 @@ function getPersistedMessages(input: {
     ...persisted.slice(0, responseIndex),
     latestUserMessage,
     ...persisted.slice(responseIndex),
+  ];
+}
+
+function mergeSupersededStreamMessages(input: {
+  currentMessages: UIMessage[];
+  incomingMessages: UIMessage[];
+  latestUserMessageId: string | null;
+}) {
+  if (input.currentMessages.length === 0) {
+    return input.incomingMessages;
+  }
+
+  const currentIds = new Set(
+    input.currentMessages.map((message) => message.id)
+  );
+  const missingIncoming = input.incomingMessages.filter(
+    (message) => !currentIds.has(message.id)
+  );
+  if (missingIncoming.length === 0) {
+    return input.currentMessages;
+  }
+
+  if (!input.latestUserMessageId) {
+    return [...input.currentMessages, ...missingIncoming];
+  }
+
+  const latestUserIndex = input.currentMessages.findIndex(
+    (message) => message.id === input.latestUserMessageId
+  );
+  if (latestUserIndex < 0) {
+    return [...input.currentMessages, ...missingIncoming];
+  }
+
+  return [
+    ...input.currentMessages.slice(0, latestUserIndex + 1),
+    ...missingIncoming,
+    ...input.currentMessages.slice(latestUserIndex + 1),
   ];
 }
 
@@ -1714,7 +1751,6 @@ export async function POST(request: Request) {
               });
             },
             agentActivityId,
-            emitAgentActivity,
             rootFolderId: workspace.rootFolderId,
             userId: session.user.id,
             workspaceId: workspace.workspaceId,
@@ -1939,23 +1975,40 @@ export async function POST(request: Request) {
                   isContinuation,
                 });
                 const activeStreamId = await getActiveStreamId(chatSlug);
+                const latestUserMessageId =
+                  [...originalMessages]
+                    .reverse()
+                    .find((message) => message.role === "user")?.id ?? null;
+                const messagesToPersist =
+                  activeStreamId === streamId
+                    ? persistedMessages
+                    : mergeSupersededStreamMessages({
+                        currentMessages:
+                          (await getMessagesByChatSlugForUser(
+                            session.user.id,
+                            chatSlug,
+                            workspace.workspaceId
+                          )) ?? [],
+                        incomingMessages: persistedMessages,
+                        latestUserMessageId,
+                      });
                 if (activeStreamId !== streamId) {
-                  logInfo("Skipped persisting stale stream messages", {
+                  logInfo("Merging superseded stream messages", {
                     chatId: chatSlug,
-                    messageCount: messages.length,
+                    incomingMessageCount: persistedMessages.length,
+                    mergedMessageCount: messagesToPersist.length,
                     streamId,
                     activeStreamId,
                   });
-                  return;
                 }
                 logInfo("Model stream finished", {
                   chatId: chatSlug,
-                  messageCount: persistedMessages.length,
+                  messageCount: messagesToPersist.length,
                 });
                 await saveMessagesForChatSlug(
                   session.user.id,
                   chatSlug,
-                  persistedMessages,
+                  messagesToPersist,
                   workspace.workspaceId
                 );
                 try {
@@ -1974,7 +2027,7 @@ export async function POST(request: Request) {
                 await invalidateChatReadCaches(workspace.workspaceId);
                 logInfo("Persisted streamed messages", {
                   chatId: chatSlug,
-                  messageCount: persistedMessages.length,
+                  messageCount: messagesToPersist.length,
                 });
 
                 try {
@@ -1983,7 +2036,7 @@ export async function POST(request: Request) {
                   ).catch(() => null);
                   const latestUserPosition = Math.max(
                     0,
-                    persistedMessages
+                    messagesToPersist
                       .map((message, index) =>
                         message.role === "user" ? index : -1
                       )
@@ -1995,7 +2048,7 @@ export async function POST(request: Request) {
                     endedAt: new Date(),
                     latestSummary,
                     latestUserPosition,
-                    messages: persistedMessages,
+                    messages: messagesToPersist,
                     previousLastMessageAt: chat.lastMessageAt
                       ? new Date(chat.lastMessageAt)
                       : null,
@@ -2069,7 +2122,7 @@ export async function POST(request: Request) {
                   apiLogger.meter("meter.chat.request", {
                     chatId: chatSlug,
                     model: selectedModel,
-                    messageCount: persistedMessages.length,
+                    messageCount: messagesToPersist.length,
                   });
                   apiLogger.featureUsed("chat", {
                     chatId: chatSlug,

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -1979,6 +1979,9 @@ export async function POST(request: Request) {
                   [...originalMessages]
                     .reverse()
                     .find((message) => message.role === "user")?.id ?? null;
+                // Superseded streams are merged as a best-effort recovery path;
+                // a later active stream save may still win, but this avoids
+                // dropping completed superseded responses outright.
                 const messagesToPersist =
                   activeStreamId === streamId
                     ? persistedMessages

--- a/apps/web/src/app/api/flashcards/onboarding/route.ts
+++ b/apps/web/src/app/api/flashcards/onboarding/route.ts
@@ -1,4 +1,4 @@
-import { generateText, Output } from "@avenire/ai";
+import { generateText, Output, zodSchema } from "@avenire/ai";
 import { apollo } from "@avenire/ai/models";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
   const source = buildStudySource(parsed.data);
   const result = await generateText({
     model: apollo.languageModel("apollo-core"),
-    output: Output.object({ schema: flashcardGenerationSchema }),
+    output: Output.object({ schema: zodSchema(flashcardGenerationSchema) }),
     prompt: [
       "Create a clean flashcard deck from the misconception source.",
       `Return exactly ${Math.max(1, Math.min(parsed.data.count ?? 5, 12))} cards.`,

--- a/apps/web/src/components/chat/chat.tsx
+++ b/apps/web/src/components/chat/chat.tsx
@@ -10,6 +10,7 @@ import {
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from "ai";
 import { AnimatePresence, motion } from "motion/react";
+import type { Route } from "next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { toast } from "sonner";
@@ -416,7 +417,9 @@ export function Chat({
   const handleSubmit = async (inputValue: string, files: Attachment[]) => {
     if (id === "new" && !hasPushedNewChatUrlRef.current) {
       hasPushedNewChatUrlRef.current = true;
-      paneRouter.replace(`/workspace/chats/${chatId}`, { scroll: false });
+      paneRouter.replace(`/workspace/chats/${chatId}` as Route, {
+        scroll: false,
+      });
     }
 
     const localFileParts: FileUIPart[] = files

--- a/apps/web/src/components/chat/chat.tsx
+++ b/apps/web/src/components/chat/chat.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/chat-events";
 import { normalizeMediaType } from "@/lib/media-type";
 import { emitPetNotification } from "@/lib/pet-preferences";
+import { usePaneRouter } from "@/lib/workspace-panes";
 import { type Attachment, createLocalAttachment } from "./attachment";
 import { Messages } from "./messages";
 import { MultimodalInput } from "./multimodal-input";
@@ -47,9 +48,9 @@ type SendMessageOptions = Parameters<
 >[1];
 const ACTIVE_REPLY_MIN_HEIGHT = "calc(100dvh - 250px)";
 const EMPTY_COMPOSER_SHELL_CLASSNAME =
-  "mx-auto mb-3 w-full max-w-3xl px-4 md:mb-3 md:px-0";
+  "mx-auto mb-3 w-full max-w-4xl px-4 md:mb-3 md:px-0";
 const FLOATING_COMPOSER_SHELL_CLASSNAME =
-  "mx-auto w-full px-3 pb-[calc(0.6rem+env(safe-area-inset-bottom))] md:max-w-3xl md:px-0 md:pb-3";
+  "mx-auto w-full px-3 pb-[calc(0.6rem+env(safe-area-inset-bottom))] md:max-w-4xl md:px-0 md:pb-3";
 const MOBILE_CHAT_COMPOSER_CLOSE_EVENT = "avenire:mobile-chat-composer-close";
 const MOBILE_CHAT_COMPOSER_OPEN_EVENT = "avenire:mobile-chat-composer-open";
 const MOBILE_CHAT_COMPOSER_STATE_EVENT = "avenire:mobile-chat-composer-state";
@@ -75,6 +76,7 @@ export function Chat({
   const [mobileComposerOpen, setMobileComposerOpen] = useState(false);
   const [turboEnabled, setTurboEnabled] = useState(false);
   const isMobile = useIsMobile();
+  const paneRouter = usePaneRouter();
   const activeSelectedModel = turboEnabled ? "apex-turbo" : selectedModel;
   const lastCompletedMessageIdRef = useRef<string | null>(null);
   const previousStatusRef = useRef<string | null>(null);
@@ -412,6 +414,11 @@ export function Chat({
   );
 
   const handleSubmit = async (inputValue: string, files: Attachment[]) => {
+    if (id === "new" && !hasPushedNewChatUrlRef.current) {
+      hasPushedNewChatUrlRef.current = true;
+      paneRouter.replace(`/workspace/chats/${chatId}`, { scroll: false });
+    }
+
     const localFileParts: FileUIPart[] = files
       .filter((attachment) => attachment.source === "local")
       .flatMap((attachment) => {
@@ -617,7 +624,7 @@ export function Chat({
                 key="composer-center"
                 transition={{ duration: 0.24, ease: "easeOut" }}
               >
-                <div className="relative flex w-full flex-col items-center justify-center md:max-w-3xl">
+                <div className="relative flex w-full flex-col items-center justify-center md:max-w-4xl">
                   {isEmptyState ? (
                     <div className="pointer-events-none absolute bottom-[calc(100%+2.25rem)] w-full sm:bottom-[calc(100%+3rem)]">
                       <Overview userName={userName} />

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -666,7 +666,7 @@ const PurePreviewMessage = ({
     <AnimatePresence>
       <motion.div
         animate={{ y: 0, opacity: 1 }}
-        className={cn("group/message mx-auto w-full max-w-3xl px-3 sm:px-4", {
+        className={cn("group/message mx-auto w-full max-w-4xl px-3 sm:px-4", {
           "justify-self-end": message.role === "user",
         })}
         data-message-id={message.id}

--- a/apps/web/src/components/chat/rolling-tool-activity.tsx
+++ b/apps/web/src/components/chat/rolling-tool-activity.tsx
@@ -134,27 +134,13 @@ type ActionGroup =
   | { action: MutationAction; type: "mutation" };
 
 const ROLLING_TOOL_TYPES = new Set([
-  "tool-avenire_agent",
-  "tool-file_manager_agent",
   "tool-generate_flashcards",
   "tool-get_due_cards",
   "tool-log_misconception",
   "tool-note_agent",
   "tool-quiz_me",
-  "tool-web_search",
-  "tool-search_materials",
-  // Granular file operations
-  "tool-list_files",
-  "tool-read_file",
-  "tool-move_file",
-  "tool-delete_file",
-  "tool-create_folder",
-  "tool-get_file_info",
-  // Granular note operations
   "tool-create_note",
-  "tool-read_note",
   "tool-update_note",
-  "tool-list_notes",
   "tool-update_note_tags",
 ]);
 
@@ -807,7 +793,7 @@ export const Reasoning = memo(
     return (
       <ReasoningContext.Provider value={contextValue}>
         <Collapsible
-          className={cn("not-prose mb-4", className)}
+          className={cn("not-prose mb-2", className)}
           onOpenChange={handleOpenChange}
           open={isOpen}
           {...props}

--- a/apps/web/src/components/chat/rolling-tool-activity.tsx
+++ b/apps/web/src/components/chat/rolling-tool-activity.tsx
@@ -546,6 +546,25 @@ function toAction(part: ToolPart): ActivityAction | null {
     };
   }
 
+  if (part.type === "tool-get_due_cards") {
+    const totalDueCount = isOutputAvailable(part)
+      ? part.output.totalDueCount
+      : undefined;
+    return {
+      kind: "flashcards",
+      pending: isPending(part),
+      preview:
+        typeof totalDueCount === "number"
+          ? {
+              cardCount: totalDueCount,
+              setId: "",
+              title: "Due cards",
+            }
+          : undefined,
+      value: "due cards",
+    };
+  }
+
   if (part.type === "tool-log_misconception") {
     const output = isOutputAvailable(part) ? part.output : null;
     const misconception = output?.misconception;

--- a/apps/web/src/lib/chat-tools/chat-tool-note-runtime.test.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-note-runtime.test.ts
@@ -25,6 +25,7 @@ vi.mock("@avenire/ai", () => ({
   Output: {
     object: ({ schema }: { schema: unknown }) => schema,
   },
+  zodSchema: (schema: unknown) => schema,
 }));
 
 vi.mock("@avenire/ai/models", () => ({

--- a/apps/web/src/lib/chat-tools/chat-tool-note-runtime.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-note-runtime.ts
@@ -1,4 +1,4 @@
-import { generateText, Output } from "@avenire/ai";
+import { generateText, Output, zodSchema } from "@avenire/ai";
 import { apollo } from "@avenire/ai/models";
 import { scheduleIngestionJob } from "@avenire/ingestion/queue";
 import {
@@ -35,7 +35,7 @@ export async function generateNoteDraftFromTask(input: {
 }) {
   const result = await generateText({
     model: apollo.languageModel("apollo-core"),
-    output: Output.object({ schema: noteDraftSchema }),
+    output: Output.object({ schema: zodSchema(noteDraftSchema) }),
     prompt: [
       "Write a clean markdown note from the request.",
       "Return a concise, specific title and a polished markdown body.",
@@ -69,7 +69,7 @@ export async function rewriteNoteFromTask(input: {
 }) {
   const result = await generateText({
     model: apollo.languageModel("apollo-core"),
-    output: Output.object({ schema: noteRewriteSchema }),
+    output: Output.object({ schema: zodSchema(noteRewriteSchema) }),
     prompt: [
       "Revise the markdown note to satisfy the edit request.",
       "Return the full updated markdown note, not a diff.",

--- a/apps/web/src/lib/chat-tools/chat-tool-study-runtime.test.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-study-runtime.test.ts
@@ -38,6 +38,7 @@ vi.mock("@avenire/ai", () => ({
   Output: {
     object: ({ schema }: { schema: unknown }) => schema,
   },
+  zodSchema: (schema: unknown) => schema,
 }));
 
 vi.mock("@avenire/ai/models", () => ({

--- a/apps/web/src/lib/chat-tools/chat-tool-study-runtime.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-study-runtime.ts
@@ -1,4 +1,4 @@
-import { generateText, Output } from "@avenire/ai";
+import { generateText, Output, zodSchema } from "@avenire/ai";
 import { apollo } from "@avenire/ai/models";
 import type { chatToolSchemas } from "@avenire/ai/tools";
 import { getIngestionSummaryForFile } from "@avenire/database";
@@ -273,7 +273,7 @@ export async function generateFlashcardsFromSource(
   });
   const result = await generateText({
     model: apollo.languageModel("apollo-core"),
-    output: Output.object({ schema: flashcardGenerationSchema }),
+    output: Output.object({ schema: zodSchema(flashcardGenerationSchema) }),
     prompt: [
       "Create a clean Mindset Set from the study material.",
       "Write concise markdown front/back pairs.",
@@ -343,7 +343,7 @@ export async function generateQuizFromSource(
   });
   const result = await generateText({
     model: apollo.languageModel("apollo-core"),
-    output: Output.object({ schema: quizGenerationSchema }),
+    output: Output.object({ schema: zodSchema(quizGenerationSchema) }),
     prompt: [
       "Create a multiple choice quiz from the study material.",
       "Each question must have 4 options when possible.",

--- a/apps/web/src/lib/chat-tools/chat-tool-workspace-agent-runtime.test.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-workspace-agent-runtime.test.ts
@@ -27,6 +27,7 @@ vi.mock("@avenire/ai", () => ({
   Output: {
     object: ({ schema }: { schema: unknown }) => schema,
   },
+  zodSchema: (schema: unknown) => schema,
 }));
 
 vi.mock("@avenire/ai/models", () => ({

--- a/apps/web/src/lib/chat-tools/chat-tool-workspace-agent-runtime.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-workspace-agent-runtime.ts
@@ -1,4 +1,4 @@
-import { generateText, Output } from "@avenire/ai";
+import { generateText, Output, zodSchema } from "@avenire/ai";
 import type {
   AgentActivityAction,
   AgentActivityData,
@@ -144,7 +144,7 @@ export async function executeAvenireAgent(
   if (selectableMatches.length > 0) {
     const selection = await generateText({
       model: apollo.languageModel("apollo-agent"),
-      output: Output.object({ schema: agentSelectionSchema }),
+      output: Output.object({ schema: zodSchema(agentSelectionSchema) }),
       prompt: buildAgentSelectionPrompt({
         query: input.query,
         matches: selectableMatches,
@@ -337,7 +337,7 @@ export async function executeFileManagerAgent(
   if (candidateFiles.length > 0) {
     const selection = await generateText({
       model: apollo.languageModel("apollo-agent"),
-      output: Output.object({ schema: agentSelectionSchema }),
+      output: Output.object({ schema: zodSchema(agentSelectionSchema) }),
       prompt: buildFileManagerSelectionPrompt({
         files: candidateFiles,
         maxFiles,

--- a/apps/web/src/lib/session-summaries.ts
+++ b/apps/web/src/lib/session-summaries.ts
@@ -1,4 +1,4 @@
-import { generateText, Output } from "@avenire/ai";
+import { generateText, Output, zodSchema } from "@avenire/ai";
 import type { UIMessage } from "@avenire/ai/message-types";
 import { apollo } from "@avenire/ai/models";
 import {
@@ -561,7 +561,7 @@ export async function persistSessionSummaryForCompletedTurn(input: {
 
   const result = await generateText({
     model: apollo.languageModel(SUMMARY_MODEL),
-    output: Output.object({ schema: summaryOutputSchema }),
+    output: Output.object({ schema: zodSchema(summaryOutputSchema) }),
     prompt: [
       "Classify and summarize this completed chat session window for learning memory.",
       "Return concise, factual output only.",


### PR DESCRIPTION
## Summary
- raise chat title generation output budget for Groq GPT-OSS reasoning tokens
- wrap AI SDK structured output schemas with zodSchema for flashcards and adjacent generation paths
- replace new chat URL on first send, merge superseded stream messages, widen chat layout, and simplify rolling tool activity

## Verification
- targeted apollo-core structured flashcard generation returned valid JSON
- pnpm --filter @avenire/web check-types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic URL navigation when starting a new chat with the first message.

* **Bug Fixes**
  * Improved message persistence when multiple chat streams are active simultaneously.

* **Enhancements**
  * Chat titles can now generate longer text for more detailed summaries.
  * Increased composer and message display width for better readability.
  * Refined tool activity indicators displayed during chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->