### PR TITLE
Fix link ingestion responsiveness and composer wrapping

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -17,6 +17,7 @@
     "@avenire/database": "workspace:*",
     "@avenire/ingestion": "workspace:*",
     "@avenire/observability": "workspace:*",
+    "@avenire/storage": "workspace:*",
     "@hono/node-server": "^1.19.12",
     "dotenv": "latest",
     "hono": "^4.12.9",

--- a/apps/backend/src/ingestion-worker.ts
+++ b/apps/backend/src/ingestion-worker.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -10,10 +11,12 @@ import {
   markNoteReindexed,
   replaceFileTranscriptCues,
   retryIngestionJob,
+  updateLinkPreviewMetadataAfterIngestion,
 } from "@avenire/database";
 import {
   assertRequiredSecrets,
   ingestStoredFile,
+  type LinkPreview,
   warmWorkspace,
 } from "@avenire/ingestion";
 import {
@@ -28,6 +31,7 @@ import {
   scopedLogger,
   shutdownObservability,
 } from "@avenire/observability";
+import { uploadStorageFile } from "@avenire/storage";
 import { serve } from "@hono/node-server";
 import { config as loadEnv } from "dotenv";
 import { Hono } from "hono";
@@ -87,6 +91,98 @@ function isNonRetryableIngestionError(stage: string, error: unknown) {
     stage === "load-file" &&
     error.message === "File not found for ingestion job."
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getScreenshotExtension(contentType: string) {
+  if (contentType.includes("webp")) {
+    return "webp";
+  }
+  if (contentType.includes("jpeg")) {
+    return "jpg";
+  }
+  return "png";
+}
+
+async function persistLinkPreviewImage(input: {
+  imageUrl: string | null;
+  sourceUrl: string;
+}) {
+  if (!(input.imageUrl && process.env.UPLOADTHING_TOKEN)) {
+    return input.imageUrl;
+  }
+
+  const response = await fetch(input.imageUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to download link screenshot: ${response.status}`);
+  }
+  const contentType = response.headers.get("content-type") ?? "image/png";
+  if (!contentType.toLowerCase().startsWith("image/")) {
+    throw new Error("Link screenshot response was not an image.");
+  }
+
+  const sourceHash = createHash("sha256").update(input.sourceUrl).digest("hex");
+  const extension = getScreenshotExtension(contentType);
+  const uploaded = await uploadStorageFile({
+    body: new Uint8Array(await response.arrayBuffer()),
+    contentType,
+    key: `uploads/link-previews/${sourceHash}.${extension}`,
+    name: `link-preview-${sourceHash}.${extension}`,
+  });
+  return uploaded.url;
+}
+
+async function persistLinkPreviewMetadata(input: {
+  fileId: string;
+  preview: LinkPreview;
+  sourceUrl: string;
+  workspaceId: string;
+}) {
+  const imageUrl = await persistLinkPreviewImage({
+    imageUrl: input.preview.imageUrl,
+    sourceUrl: input.sourceUrl,
+  });
+  const snapshot = input.preview.snapshot
+    ? { ...input.preview.snapshot, imageUrl }
+    : null;
+  const updated = await updateLinkPreviewMetadataAfterIngestion({
+    workspaceId: input.workspaceId,
+    fileId: input.fileId,
+    favicon: input.preview.favicon,
+    sourceUrl: input.sourceUrl,
+    link: {
+      content: input.preview.content,
+      description: input.preview.description,
+      displayMode: input.preview.displayMode,
+      extractionMode: input.preview.mode,
+      favicon: input.preview.favicon,
+      imageUrl,
+      kind: input.preview.kind,
+      mediaUrls: input.preview.mediaUrls,
+      provider: input.preview.provider ?? null,
+      readerMarkdown: input.preview.readerMarkdown,
+      snapshot,
+      sourceUrl: input.sourceUrl,
+      title: input.preview.title,
+    },
+  });
+
+  if (updated) {
+    await publishWorkspaceStreamEvent({
+      workspaceUuid: input.workspaceId,
+      type: "files.invalidate",
+      payload: {
+        at: Date.now(),
+        fileId: updated.id,
+        folderId: updated.folderId,
+        reason: "file.updated",
+        workspaceUuid: input.workspaceId,
+      },
+    });
+  }
 }
 
 async function publishIngestionEvent(input: {
@@ -187,6 +283,22 @@ async function processQueuedJob(queueJob: IngestionQueueJobData) {
       metadata: file.metadata,
       content: file.isNote ? (file.content ?? "") : null,
     });
+
+    if (result.linkPreview) {
+      const linkMetadata = isRecord(file.metadata.link)
+        ? file.metadata.link
+        : null;
+      const sourceUrl = linkMetadata?.sourceUrl;
+      if (typeof sourceUrl === "string" && sourceUrl.length > 0) {
+        stage = "persist-link-preview";
+        await persistLinkPreviewMetadata({
+          fileId: file.id,
+          preview: result.linkPreview,
+          sourceUrl,
+          workspaceId: job.workspaceId,
+        });
+      }
+    }
 
     stage = "persist-transcript";
     await replaceFileTranscriptCues({

--- a/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-model.test.ts
+++ b/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-model.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveWorkspaceLinkDocumentTitle,
+  deriveWorkspaceLinkFaviconUrl,
+} from "./workspace-links-route-model";
+
+describe("workspace link route model", () => {
+  it("builds a lightweight title without waiting for extracted metadata", () => {
+    expect(
+      deriveWorkspaceLinkDocumentTitle({
+        normalizedUrl: "https://example.com/guides/optimistic-ingestion",
+        previewTitle: "",
+        requestedName: "",
+      })
+    ).toEqual({
+      fileName: "example.com optimistic ingestion.md",
+      noteTitle: "example.com optimistic ingestion",
+    });
+  });
+
+  it("uses an origin-relative favicon while ingestion is pending", () => {
+    expect(
+      deriveWorkspaceLinkFaviconUrl("https://example.com/guides/article")
+    ).toBe("https://example.com/favicon.ico");
+  });
+});

--- a/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-model.ts
+++ b/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-model.ts
@@ -1,5 +1,5 @@
-import { resolveApiErrorMessage } from "@/lib/api-error-message";
 import { Schema } from "effect-v4";
+import { resolveApiErrorMessage } from "@/lib/api-error-message";
 
 export const workspaceLinkCreateSchema = Schema.Struct({
   folderId: Schema.optional(Schema.String),
@@ -84,6 +84,10 @@ export function deriveWorkspaceLinkDocumentTitle(input: {
     fileName,
     noteTitle,
   };
+}
+
+export function deriveWorkspaceLinkFaviconUrl(normalizedUrl: string) {
+  return new URL("/favicon.ico", normalizedUrl).toString();
 }
 
 export function buildWorkspaceLinkNoteContent(input: {

--- a/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-post.ts
+++ b/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-post.ts
@@ -1,10 +1,5 @@
-import { createHash } from "node:crypto";
-import { findReusableIngestionResource } from "@avenire/database";
-import { extractLinkPreview } from "@avenire/ingestion/link";
 import { scheduleIngestionJob } from "@avenire/ingestion/queue";
-import { uploadStorageFile } from "@avenire/storage";
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { canStoreBytes } from "@/lib/billing";
 import {
   createWorkspaceNoteFile,
@@ -17,6 +12,7 @@ import {
   buildWorkspaceLinkNoteContent,
   buildWorkspaceLinkQueuedEvent,
   deriveWorkspaceLinkDocumentTitle,
+  deriveWorkspaceLinkFaviconUrl,
   normalizeWorkspaceLinkUrl,
 } from "./workspace-links-route-model";
 
@@ -24,65 +20,6 @@ interface WorkspaceLinksRouteBody {
   folderId?: string;
   name?: string;
   url?: string;
-}
-
-const ReusableLinkResourceSchema = z.object({
-  imageUrl: z.string().url().nullable().optional(),
-});
-
-function getScreenshotExtension(contentType: string) {
-  if (contentType.includes("webp")) {
-    return "webp";
-  }
-  if (contentType.includes("jpeg")) {
-    return "jpg";
-  }
-  return "png";
-}
-
-async function persistLinkPreviewImage(input: {
-  imageUrl: string | null;
-  sourceUrl: string;
-}) {
-  if (!input.imageUrl) {
-    return null;
-  }
-
-  const reusable = await findReusableIngestionResource({
-    source: input.sourceUrl,
-    sourceType: "link",
-  });
-  const reusableMetadata = ReusableLinkResourceSchema.safeParse(
-    reusable?.metadata
-  );
-  if (reusableMetadata.success && reusableMetadata.data.imageUrl) {
-    return reusableMetadata.data.imageUrl;
-  }
-
-  if (!process.env.UPLOADTHING_TOKEN) {
-    return input.imageUrl;
-  }
-
-  const response = await fetch(input.imageUrl);
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download Firecrawl screenshot: ${response.status}`
-    );
-  }
-  const contentType = response.headers.get("content-type") ?? "image/png";
-  if (!contentType.toLowerCase().startsWith("image/")) {
-    throw new Error("Firecrawl screenshot response was not an image.");
-  }
-
-  const sourceHash = createHash("sha256").update(input.sourceUrl).digest("hex");
-  const extension = getScreenshotExtension(contentType);
-  const uploaded = await uploadStorageFile({
-    body: new Uint8Array(await response.arrayBuffer()),
-    contentType,
-    key: `uploads/link-previews/${sourceHash}.${extension}`,
-    name: `link-preview-${sourceHash}.${extension}`,
-  });
-  return uploaded.url;
 }
 
 export async function handleWorkspaceLinksPost(input: {
@@ -116,28 +53,16 @@ export async function handleWorkspaceLinksPost(input: {
     return NextResponse.json({ error: "Read-only folder" }, { status: 403 });
   }
 
-  const extractedPreview = await extractLinkPreview(normalizedUrl);
-  const imageUrl = await persistLinkPreviewImage({
-    imageUrl: extractedPreview.imageUrl,
-    sourceUrl: normalizedUrl,
-  });
-  const linkPreview = {
-    ...extractedPreview,
-    imageUrl,
-    snapshot: extractedPreview.snapshot
-      ? { ...extractedPreview.snapshot, imageUrl }
-      : null,
-  };
   const { fileName, noteTitle } = deriveWorkspaceLinkDocumentTitle({
     requestedName,
-    previewTitle: linkPreview.title ?? "",
+    previewTitle: "",
     normalizedUrl,
   });
   const content = buildWorkspaceLinkNoteContent({
-    displayMode: linkPreview.displayMode,
     title: noteTitle,
     url: normalizedUrl,
   });
+  const faviconUrl = deriveWorkspaceLinkFaviconUrl(normalizedUrl);
   const storage = await canStoreBytes(
     input.userId,
     Buffer.byteLength(content, "utf8")
@@ -159,23 +84,11 @@ export async function handleWorkspaceLinksPost(input: {
       type: "note",
       resourceType: "link-resource",
       link: {
-        content: linkPreview.content,
-        description: linkPreview.description,
-        displayMode: linkPreview.displayMode,
-        extractionMode: linkPreview.mode,
-        favicon: linkPreview.favicon,
-        imageUrl: linkPreview.imageUrl,
-        kind: linkPreview.kind,
-        mediaUrls: linkPreview.mediaUrls,
-        provider: linkPreview.provider ?? null,
-        readerMarkdown: linkPreview.readerMarkdown,
-        snapshot: linkPreview.snapshot,
-        title: linkPreview.title,
         sourceUrl: normalizedUrl,
       },
       page: {
         bannerUrl: null,
-        icon: linkPreview.favicon ?? "🔗",
+        icon: faviconUrl,
         properties: {
           source: {
             type: "text",

--- a/apps/web/src/components/chat/composer-layout.test.ts
+++ b/apps/web/src/components/chat/composer-layout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldUseMultilineComposer,
+  TEXTAREA_MULTILINE_HEIGHT,
+} from "./composer-layout";
+
+describe("chat composer layout", () => {
+  it("expands for a soft-wrapped line measured at the compact width", () => {
+    expect(
+      shouldUseMultilineComposer({
+        measuredHeight: TEXTAREA_MULTILINE_HEIGHT + 1,
+        value: "A long line that wraps without an explicit newline",
+      })
+    ).toBe(true);
+  });
+
+  it("keeps explicit newlines expanded", () => {
+    expect(
+      shouldUseMultilineComposer({
+        measuredHeight: TEXTAREA_MULTILINE_HEIGHT,
+        value: "First line\nSecond line",
+      })
+    ).toBe(true);
+  });
+
+  it("collapses a short single line", () => {
+    expect(
+      shouldUseMultilineComposer({
+        measuredHeight: TEXTAREA_MULTILINE_HEIGHT,
+        value: "Short message",
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/composer-layout.ts
+++ b/apps/web/src/components/chat/composer-layout.ts
@@ -1,0 +1,11 @@
+export const TEXTAREA_MULTILINE_HEIGHT = 40;
+
+export function shouldUseMultilineComposer(input: {
+  measuredHeight: number;
+  value: string;
+}) {
+  return (
+    input.value.includes("\n") ||
+    input.measuredHeight > TEXTAREA_MULTILINE_HEIGHT
+  );
+}

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -305,6 +305,7 @@ function PureMultimodalInput({
   const hasHydratedInputRef = useRef(false);
   const uploadingIdsRef = useRef(new Set<string>());
   const compactTextareaWidthRef = useRef<number | null>(null);
+  const multilineControlWidthRef = useRef<number | null>(null);
   const [textareaSelection, setTextareaSelection] = useState({
     start: 0,
     end: 0,
@@ -552,8 +553,24 @@ function PureMultimodalInput({
       return;
     }
 
+    const currentTextareaWidth =
+      width > 0 ? textarea.getBoundingClientRect().width : textarea.clientWidth;
     if (!isMultiLine) {
-      compactTextareaWidthRef.current = textarea.getBoundingClientRect().width;
+      compactTextareaWidthRef.current = currentTextareaWidth;
+      multilineControlWidthRef.current = null;
+    } else if (
+      multilineControlWidthRef.current === null &&
+      compactTextareaWidthRef.current !== null
+    ) {
+      multilineControlWidthRef.current = Math.max(
+        0,
+        currentTextareaWidth - compactTextareaWidthRef.current
+      );
+    } else if (multilineControlWidthRef.current !== null) {
+      compactTextareaWidthRef.current = Math.max(
+        1,
+        currentTextareaWidth - multilineControlWidthRef.current
+      );
     }
     const compactWidth = compactTextareaWidthRef.current;
     const measuredHeight = compactWidth
@@ -568,7 +585,7 @@ function PureMultimodalInput({
     if (nextIsMultiLine !== isMultiLine) {
       setIsMultiLine(nextIsMultiLine);
     }
-  }, [input, isMultiLine]);
+  }, [input, isMultiLine, width]);
 
   useEffect(() => {
     if (hasHydratedInputRef.current) {

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -32,6 +32,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -44,6 +45,7 @@ import {
   createWorkspaceAttachment,
   revokeAttachmentUrl,
 } from "@/components/chat/attachment";
+import { shouldUseMultilineComposer } from "@/components/chat/composer-layout";
 import { PreviewAttachment } from "@/components/chat/preview-attachment";
 import {
   CHAT_COMPOSER_SEND_MODE_STORAGE_KEY,
@@ -92,6 +94,20 @@ function syncTextareaHeight(textarea: HTMLTextAreaElement) {
   textarea.style.height = `${nextHeight}px`;
   textarea.style.overflowY =
     textarea.scrollHeight > TEXTAREA_MAX_HEIGHT ? "auto" : "hidden";
+}
+
+function measureTextareaHeightAtWidth(
+  textarea: HTMLTextAreaElement,
+  width: number
+) {
+  const previousHeight = textarea.style.height;
+  const previousWidth = textarea.style.width;
+  textarea.style.height = "auto";
+  textarea.style.width = `${width}px`;
+  const measuredHeight = textarea.scrollHeight;
+  textarea.style.height = previousHeight;
+  textarea.style.width = previousWidth;
+  return measuredHeight;
 }
 
 interface WorkspaceTreeFolder {
@@ -288,6 +304,7 @@ function PureMultimodalInput({
   const latestInputRef = useRef(input);
   const hasHydratedInputRef = useRef(false);
   const uploadingIdsRef = useRef(new Set<string>());
+  const compactTextareaWidthRef = useRef<number | null>(null);
   const [textareaSelection, setTextareaSelection] = useState({
     start: 0,
     end: 0,
@@ -528,14 +545,30 @@ function PureMultimodalInput({
         : "What do you want to learn?";
   const isVoiceInputActive = isRecording || isTranscribing;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     latestInputRef.current = input;
-    if (!textareaRef.current) {
+    const textarea = textareaRef.current;
+    if (!textarea) {
       return;
     }
-    syncTextareaHeight(textareaRef.current);
-    setIsMultiLine(textareaRef.current.scrollHeight > 40);
-  }, [input]);
+
+    if (!isMultiLine) {
+      compactTextareaWidthRef.current = textarea.getBoundingClientRect().width;
+    }
+    const compactWidth = compactTextareaWidthRef.current;
+    const measuredHeight = compactWidth
+      ? measureTextareaHeightAtWidth(textarea, compactWidth)
+      : textarea.scrollHeight;
+    const nextIsMultiLine = shouldUseMultilineComposer({
+      measuredHeight,
+      value: input,
+    });
+
+    syncTextareaHeight(textarea);
+    if (nextIsMultiLine !== isMultiLine) {
+      setIsMultiLine(nextIsMultiLine);
+    }
+  }, [input, isMultiLine]);
 
   useEffect(() => {
     if (hasHydratedInputRef.current) {
@@ -1629,9 +1662,7 @@ function PureComposerActionButton({
 }) {
   const disabled = !(isRunning || canSend);
   const reduceMotion = useReducedMotion() ?? false;
-  const iconEnter = reduceMotion
-    ? { opacity: 0 }
-    : { opacity: 0, scale: 0.94 };
+  const iconEnter = reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.94 };
   const iconExit = reduceMotion
     ? { opacity: 0, transition: { duration: 0.06 } }
     : { opacity: 0, scale: 0.94, transition: { duration: 0.06 } };

--- a/apps/web/src/components/files/explorer.tsx
+++ b/apps/web/src/components/files/explorer.tsx
@@ -1522,6 +1522,17 @@ function createPendingLinkImport(input: {
   };
 }
 
+function normalizeLinkImportUrl(value: string) {
+  const withProtocol = /^[a-z][a-z\d+.-]*:/i.test(value)
+    ? value
+    : `https://${value}`;
+  const parsed = new URL(withProtocol);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Please enter a valid HTTP or HTTPS URL.");
+  }
+  return parsed.toString();
+}
+
 function PendingLinkImportCard({ item }: { item: PendingLinkImport }) {
   return (
     <Card
@@ -1952,20 +1963,26 @@ export function FileExplorer({
       return;
     }
 
-    const normalizedUrl = linkImportDialog.url.trim();
-    if (!normalizedUrl) {
+    const enteredUrl = linkImportDialog.url.trim();
+    if (!enteredUrl) {
       return;
     }
 
     const dialog = linkImportDialog;
-    const pendingImport = createPendingLinkImport({
-      folderId: dialog.folderId,
-      name: dialog.name,
-      url: normalizedUrl,
-    });
-    setPendingLinkImports((previous) => [...previous, pendingImport]);
-    setLinkImportDialog(null);
+    let pendingImport: PendingLinkImport | null = null;
     try {
+      const normalizedUrl = normalizeLinkImportUrl(enteredUrl);
+      const nextPendingImport = createPendingLinkImport({
+        folderId: dialog.folderId,
+        name: dialog.name,
+        url: normalizedUrl,
+      });
+      pendingImport = nextPendingImport;
+      setPendingLinkImports((previous) => [
+        ...previous,
+        nextPendingImport,
+      ]);
+      setLinkImportDialog(null);
       const response = await fetch(`/api/workspaces/${workspaceUuid}/links`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2009,9 +2026,12 @@ export function FileExplorer({
         error instanceof Error ? error.message : "Unable to import link."
       );
     } finally {
-      setPendingLinkImports((previous) =>
-        previous.filter((item) => item.id !== pendingImport.id)
-      );
+      if (pendingImport) {
+        const pendingImportId = pendingImport.id;
+        setPendingLinkImports((previous) =>
+          previous.filter((item) => item.id !== pendingImportId)
+        );
+      }
     }
   }, [linkImportDialog, router, workspaceUuid]);
 

--- a/apps/web/src/components/files/explorer.tsx
+++ b/apps/web/src/components/files/explorer.tsx
@@ -1497,6 +1497,72 @@ interface FileExplorerProps {
   workspaceUuid?: string;
 }
 
+interface PendingLinkImport {
+  faviconUrl: string;
+  folderId: string;
+  id: string;
+  name: string;
+}
+
+function createPendingLinkImport(input: {
+  folderId: string;
+  name: string;
+  url: string;
+}): PendingLinkImport {
+  const parsed = new URL(input.url);
+  const requestedName = input.name.trim();
+  const inferredName = parsed.hostname.replace(/^www\./i, "");
+  const name = requestedName || inferredName || "Imported link";
+
+  return {
+    faviconUrl: new URL("/favicon.ico", parsed.origin).toString(),
+    folderId: input.folderId,
+    id: `pending-link:${crypto.randomUUID()}`,
+    name: /\.mdx?$/i.test(name) ? name : `${name}.md`,
+  };
+}
+
+function PendingLinkImportCard({ item }: { item: PendingLinkImport }) {
+  return (
+    <Card
+      aria-label={`Importing ${item.name}`}
+      aria-live="polite"
+      className="relative w-40 overflow-hidden rounded-md border border-transparent bg-transparent p-2"
+      style={{ width: 160 }}
+    >
+      <CardContent className="px-0 pt-0">
+        <div className="relative flex h-28 items-center justify-center overflow-hidden rounded-md border border-border/60 bg-muted/70">
+          <LinkSimple
+            aria-hidden="true"
+            className="size-8 text-muted-foreground/60"
+          />
+          <img
+            alt=""
+            className="absolute max-h-10 max-w-10 object-contain"
+            height={40}
+            onError={(event) => {
+              event.currentTarget.style.display = "none";
+            }}
+            referrerPolicy="no-referrer"
+            src={item.faviconUrl}
+            width={40}
+          />
+          <Spinner className="absolute right-2 bottom-2 size-4 text-muted-foreground" />
+        </div>
+        <div className="mt-2 flex min-w-0 items-center gap-2">
+          <LinkSimple
+            aria-hidden="true"
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+          <span className="min-w-0 flex-1 truncate font-medium text-sm">
+            {item.name}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export function FileExplorer({
   folderUuid: folderUuidFromPage,
   workspaceUuid: workspaceUuidFromPage,
@@ -1646,7 +1712,9 @@ export function FileExplorer({
     name: string;
     url: string;
   } | null>(null);
-  const [linkImportBusy, setLinkImportBusy] = useState(false);
+  const [pendingLinkImports, setPendingLinkImports] = useState<
+    PendingLinkImport[]
+  >([]);
   const [mobileCreateMenuOpen, setMobileCreateMenuOpen] = useState(false);
   const [mobileConfirmAction, setMobileConfirmAction] = useState<
     "delete" | "move" | null
@@ -1885,18 +1953,25 @@ export function FileExplorer({
     }
 
     const normalizedUrl = linkImportDialog.url.trim();
-    if (!normalizedUrl || linkImportBusy) {
+    if (!normalizedUrl) {
       return;
     }
 
-    setLinkImportBusy(true);
+    const dialog = linkImportDialog;
+    const pendingImport = createPendingLinkImport({
+      folderId: dialog.folderId,
+      name: dialog.name,
+      url: normalizedUrl,
+    });
+    setPendingLinkImports((previous) => [...previous, pendingImport]);
+    setLinkImportDialog(null);
     try {
       const response = await fetch(`/api/workspaces/${workspaceUuid}/links`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          folderId: linkImportDialog.folderId,
-          name: linkImportDialog.name,
+          folderId: dialog.folderId,
+          name: dialog.name,
           url: normalizedUrl,
         }),
       });
@@ -1909,8 +1984,20 @@ export function FileExplorer({
         throw new Error(payload.error ?? "Unable to import link.");
       }
 
-      const targetFolderId = linkImportDialog.folderId;
-      setLinkImportDialog(null);
+      const importedFile = payload.file;
+      const targetFolderId = dialog.folderId;
+      setAllFiles((previous) =>
+        previous.some((file) => file.id === importedFile.id)
+          ? previous
+          : [...previous, importedFile]
+      );
+      if (currentFolderIdRef.current === targetFolderId) {
+        setFiles((previous) =>
+          previous.some((file) => file.id === importedFile.id)
+            ? previous
+            : [...previous, importedFile]
+        );
+      }
       toast.success("Link saved and queued for ingestion.");
       const params = new URLSearchParams();
       params.set("file", payload.file.id);
@@ -1922,9 +2009,11 @@ export function FileExplorer({
         error instanceof Error ? error.message : "Unable to import link."
       );
     } finally {
-      setLinkImportBusy(false);
+      setPendingLinkImports((previous) =>
+        previous.filter((item) => item.id !== pendingImport.id)
+      );
     }
-  }, [linkImportBusy, linkImportDialog, router, workspaceUuid]);
+  }, [linkImportDialog, router, workspaceUuid]);
 
   const parentFolder = useMemo(() => breadcrumbs.at(-2) ?? null, [breadcrumbs]);
   const isAtWorkspaceRoot = breadcrumbs.length <= 1;
@@ -6754,6 +6843,12 @@ export function FileExplorer({
                           );
                         })}
 
+                        {pendingLinkImports
+                          .filter((item) => item.folderId === currentFolderId)
+                          .map((item) => (
+                            <PendingLinkImportCard item={item} key={item.id} />
+                          ))}
+
                         {sortedFiles.map((file) => {
                           const {
                             isImage,
@@ -8053,7 +8148,7 @@ export function FileExplorer({
 
       <Dialog
         onOpenChange={(open) => {
-          if (!(open || linkImportBusy)) {
+          if (!open) {
             setLinkImportDialog(null);
           }
         }}
@@ -8117,7 +8212,6 @@ export function FileExplorer({
           </div>
           <DialogFooter>
             <Button
-              disabled={linkImportBusy}
               onClick={() => setLinkImportDialog(null)}
               type="button"
               variant="ghost"
@@ -8125,13 +8219,12 @@ export function FileExplorer({
               Cancel
             </Button>
             <Button
-              disabled={!linkImportDialog?.url.trim() || linkImportBusy}
+              disabled={!linkImportDialog?.url.trim()}
               onClick={() => {
                 void importLinkAsResource();
               }}
               type="button"
             >
-              {linkImportBusy ? <Spinner className="size-4" /> : null}
               Save link
             </Button>
           </DialogFooter>

--- a/packages/database/src/ingestion-data.ts
+++ b/packages/database/src/ingestion-data.ts
@@ -616,7 +616,8 @@ export async function updateLinkPreviewMetadataAfterIngestion(input: {
       .select({ metadata: fileAsset.metadata })
       .from(fileAsset)
       .where(where)
-      .limit(1);
+      .limit(1)
+      .for("update");
     if (!existing) {
       return null;
     }

--- a/packages/database/src/ingestion-data.ts
+++ b/packages/database/src/ingestion-data.ts
@@ -595,6 +595,75 @@ export async function getFileForIngestion(workspaceId: string, fileId: string) {
   };
 }
 
+function isMetadataRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function updateLinkPreviewMetadataAfterIngestion(input: {
+  favicon: string | null;
+  fileId: string;
+  link: Record<string, unknown>;
+  sourceUrl: string;
+  workspaceId: string;
+}) {
+  return db.transaction(async (tx) => {
+    const where = and(
+      eq(fileAsset.id, input.fileId),
+      eq(fileAsset.workspaceId, input.workspaceId),
+      isNull(fileAsset.deletedAt)
+    );
+    const [existing] = await tx
+      .select({ metadata: fileAsset.metadata })
+      .from(fileAsset)
+      .where(where)
+      .limit(1);
+    if (!existing) {
+      return null;
+    }
+
+    const metadata = isMetadataRecord(existing.metadata)
+      ? existing.metadata
+      : {};
+    const page = isMetadataRecord(metadata.page) ? metadata.page : {};
+    const properties = isMetadataRecord(page.properties)
+      ? page.properties
+      : {};
+    const pendingFavicon = new URL("/favicon.ico", input.sourceUrl).toString();
+    const currentIcon = page.icon;
+    const canReplaceIcon =
+      typeof currentIcon !== "string" ||
+      currentIcon === "🔗" ||
+      currentIcon === pendingFavicon;
+    const [record] = await tx
+      .update(fileAsset)
+      .set({
+        metadata: {
+          ...metadata,
+          link: input.link,
+          page: {
+            ...page,
+            bannerUrl: page.bannerUrl ?? null,
+            icon: canReplaceIcon
+              ? (input.favicon ?? currentIcon ?? "🔗")
+              : currentIcon,
+            properties: {
+              ...properties,
+              source: {
+                type: "text",
+                value: input.sourceUrl,
+              },
+            },
+          },
+        },
+        updatedAt: new Date(),
+      })
+      .where(where)
+      .returning({ folderId: fileAsset.folderId, id: fileAsset.id });
+
+    return record ?? null;
+  });
+}
+
 export async function findReusableIngestionResource(input: {
   source: string;
   sourceType: string;

--- a/packages/ingestion/src/index.ts
+++ b/packages/ingestion/src/index.ts
@@ -5,6 +5,7 @@ import { retrieveRelevantChunks } from "./retrieval/retrieve";
 export { assertRequiredSecrets } from "./config";
 
 export { ingestStoredFile };
+export type { LinkPreview } from "./ingestion/link";
 export { extractLinkPreview, ingestLink } from "./ingestion/link";
 export { PostgresVectorStore } from "./retrieval/postgres-vector-store";
 export type {

--- a/packages/ingestion/src/ingestion/pipeline.ts
+++ b/packages/ingestion/src/ingestion/pipeline.ts
@@ -3,7 +3,12 @@ import { PostgresVectorStore } from "../retrieval/postgres-vector-store";
 import { assertSafeUrl, safeRemoteFetch } from "../utils/safety";
 import { ingestAudio } from "./audio";
 import { ingestImage } from "./image";
-import { ingestLink, linkPreviewFromMetadata } from "./link";
+import {
+  extractLinkPreview,
+  ingestLink,
+  type LinkPreview,
+  linkPreviewFromMetadata,
+} from "./link";
 import { ingestMarkdown } from "./markdown";
 import { ingestPdfs } from "./ocr";
 import { ingestOfficeDocument } from "./office";
@@ -515,11 +520,18 @@ export const ingestStoredFile = async (input: {
     : input.fileName;
 
   let resources: CanonicalResource[] = [];
+  let linkPreview: LinkPreview | null = null;
   if (shouldIngestAsLink && linkSourceUrl) {
-    resources = isOfficeDocumentType({
+    const isOfficeLink = isOfficeDocumentType({
       fileName: linkSourceFileName,
       mimeType: inferMimeTypeFromName(linkSourceFileName) ?? "",
-    })
+    });
+    if (!isOfficeLink) {
+      linkPreview =
+        linkPreviewFromMetadata(linkMetadata) ??
+        (await extractLinkPreview(linkSourceUrl));
+    }
+    resources = isOfficeLink
       ? [
           await ingestOfficeDocument({
             source: linkSourceUrl,
@@ -527,12 +539,7 @@ export const ingestStoredFile = async (input: {
             url: linkSourceUrl,
           }),
         ]
-      : [
-          await ingestLink(
-            linkSourceUrl,
-            linkPreviewFromMetadata(linkMetadata)
-          ),
-        ];
+      : [await ingestLink(linkSourceUrl, linkPreview)];
   } else if (typeof input.content === "string") {
     resources = [
       ingestMarkdown({
@@ -631,5 +638,5 @@ export const ingestStoredFile = async (input: {
   });
 
   await logCorpusGrowth(beforeStats, vectorStore);
-  return persisted;
+  return { ...persisted, linkPreview };
 };

--- a/packages/storage/index.ts
+++ b/packages/storage/index.ts
@@ -68,16 +68,11 @@ export async function getStorageUrl(key: string) {
     return "";
   }
 
-  if (isFilesSdkStorageKey(key)) {
-    const { UTApi } = await import("uploadthing/server");
-    const utapi = new UTApi({ token: process.env.UPLOADTHING_TOKEN });
-    const response = await utapi.getFileUrls([key], { keyType: "customId" });
-    return response.data[0]?.url ?? "";
-  }
-
   const { UTApi } = await import("uploadthing/server");
   const utapi = new UTApi({ token: process.env.UPLOADTHING_TOKEN });
-  const response = await utapi.getFileUrls([key]);
+  const options: { keyType: "customId" } | undefined =
+    isFilesSdkStorageKey(key) ? { keyType: "customId" } : undefined;
+  const response = await utapi.getFileUrls([key], options);
   return response.data[0]?.url ?? "";
 }
 

--- a/packages/storage/index.ts
+++ b/packages/storage/index.ts
@@ -69,7 +69,10 @@ export async function getStorageUrl(key: string) {
   }
 
   if (isFilesSdkStorageKey(key)) {
-    return await getUploadThingFiles().url(key);
+    const { UTApi } = await import("uploadthing/server");
+    const utapi = new UTApi({ token: process.env.UPLOADTHING_TOKEN });
+    const response = await utapi.getFileUrls([key], { keyType: "customId" });
+    return response.data[0]?.url ?? "";
   }
 
   const { UTApi } = await import("uploadthing/server");
@@ -89,7 +92,7 @@ export async function uploadStorageFile(
   const result = await files.upload(key, input.body, options);
   return {
     ...result,
-    url: await files.url(result.key),
+    url: await getStorageUrl(result.key),
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@avenire/observability':
         specifier: workspace:*
         version: link:../../packages/observability
+      '@avenire/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@hono/node-server':
         specifier: 1.19.12
         version: 1.19.12(hono@4.12.25)


### PR DESCRIPTION
## Summary
- return link imports immediately with an optimistic favicon file card while extraction runs in the ingestion worker
- resolve files-sdk UploadThing custom IDs to the real public object URL before storing link screenshots
- persist completed preview metadata without overwriting concurrent file metadata edits
- stabilize chat composer soft-wrap expansion against the compact textarea width

## Validation
- `pnpm --filter @avenire/storage check-types`
- `pnpm --filter @avenire/database check-types`
- `pnpm --filter @avenire/ingestion check-types`
- `pnpm --filter @avenire/backend check-types`
- `pnpm --filter @avenire/web check-types`
- focused Vitest: link ingestion, workspace link model, composer layout (6 tests)
- React Doctor changed scope: 97/100
- supplied UploadThing URL: real object 200 image/png; encoded custom-ID URL 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Link imports now show an immediate pending card with a loading indicator, favicon placeholder, and destination folder.
  - Imported links receive refreshed preview metadata and images after processing.
  - Link entries display a favicon derived from the website address while ingestion is pending.
  - Chat composer automatically expands for wrapped or multi-line messages and remains compact for short messages.

- **Bug Fixes**
  - Improved link preview and favicon handling during ingestion.
  - Reduced unnecessary layout movement in the chat composer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->