### PR TITLE
Improve link ingestion and file card layout

### DIFF
--- a/apps/backend/src/ingestion-worker.ts
+++ b/apps/backend/src/ingestion-worker.ts
@@ -35,7 +35,10 @@ import { getStorageUrl, uploadStorageFile } from "@avenire/storage";
 import { serve } from "@hono/node-server";
 import { config as loadEnv } from "dotenv";
 import { Hono } from "hono";
-import { publishWorkspaceStreamEvent } from "./workspace-event-stream";
+import {
+  invalidateWorkspaceReadCaches,
+  publishWorkspaceStreamEvent,
+} from "./workspace-event-stream";
 
 // Prefer backend-local env; keep repo root as fallback.
 const here = fileURLToPath(new URL(".", import.meta.url));
@@ -285,6 +288,7 @@ async function persistLinkPreviewMetadata(input: {
   });
 
   if (updated) {
+    await invalidateWorkspaceReadCaches(input.workspaceId);
     await publishWorkspaceStreamEvent({
       workspaceUuid: input.workspaceId,
       type: "files.invalidate",

--- a/apps/backend/src/workspace-event-stream.ts
+++ b/apps/backend/src/workspace-event-stream.ts
@@ -3,6 +3,12 @@ import { createClient, type RedisClientType } from "redis";
 
 const redisUrl = process.env.REDIS_URL;
 const DEFAULT_MAX_LEN = 5000;
+const ROUTE_CACHE_VERSION_TTL_SECONDS = 60 * 60 * 24;
+const WORKSPACE_READ_CACHE_NAMESPACES = [
+  "workspace:folder",
+  "workspace:overview",
+  "workspace:tree",
+] as const;
 
 let publisher: RedisClientType | null = null;
 
@@ -44,6 +50,22 @@ async function getPublisherClient() {
   }
 
   return publisher;
+}
+
+export async function invalidateWorkspaceReadCaches(workspaceUuid: string) {
+  if (!redisUrl) {
+    return;
+  }
+
+  const client = await getPublisherClient();
+  const version = Date.now().toString();
+  await Promise.all(
+    WORKSPACE_READ_CACHE_NAMESPACES.map((namespace) =>
+      client.set(`${namespace}:v1:version:${workspaceUuid}`, version, {
+        EX: ROUTE_CACHE_VERSION_TTL_SECONDS,
+      })
+    )
+  );
 }
 
 export async function publishWorkspaceStreamEvent(input: {

--- a/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-post.ts
+++ b/apps/web/src/app/api/workspaces/[workspaceUuid]/links/workspace-links-route-post.ts
@@ -1,6 +1,7 @@
 import { scheduleIngestionJob } from "@avenire/ingestion/queue";
 import { after, NextResponse } from "next/server";
 import { canStoreBytes } from "@/lib/billing";
+import { invalidateWorkspaceReadCaches } from "@/lib/domain-cache";
 import {
   createWorkspaceNoteFile,
   isSharedFilesVirtualFolderId,
@@ -143,6 +144,8 @@ export async function handleWorkspaceLinksPost(input: {
       },
     },
   });
+
+  await invalidateWorkspaceReadCaches(input.workspaceUuid);
 
   scheduleLinkIngestionAfterUpload({
     workspaceUuid: input.workspaceUuid,

--- a/apps/web/src/components/files/explorer.tsx
+++ b/apps/web/src/components/files/explorer.tsx
@@ -1596,7 +1596,7 @@ function createPendingLinkImport(input: {
     faviconUrl: new URL("/favicon.ico", parsed.origin).toString(),
     folderId: input.folderId,
     id: `pending-link:${crypto.randomUUID()}`,
-    name: /\.mdx?$/i.test(name) ? name : `${name}.md`,
+    name: name.replace(/\.mdx?$/i, "") || "Imported link",
   };
 }
 
@@ -1626,13 +1626,13 @@ function PendingLinkImportCard({ item }: { item: PendingLinkImport }) {
             loading
           />
         </div>
-        <div className="mt-2 flex min-w-0 items-center gap-2">
-          <LinkSimple
-            aria-hidden="true"
-            className="size-4 shrink-0 text-muted-foreground"
-          />
-          <span className="min-w-0 flex-1 truncate font-medium text-sm">
+        <div className="mt-2 grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+          <LinkResourceTitleIcon faviconUrl={item.faviconUrl} />
+          <span className="truncate font-medium text-sm" title={item.name}>
             {item.name}
+          </span>
+          <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
+            now
           </span>
         </div>
       </CardContent>
@@ -6765,18 +6765,16 @@ export function FileExplorer({
                                         }
                                       />
                                     </div>
-                                    <div className="flex w-full min-w-0 max-w-full items-center justify-between gap-2">
-                                      <div className="flex min-w-0 flex-1 items-center gap-2">
-                                        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground">
-                                          folder
-                                        </span>
-                                        <span
-                                          className="min-w-0 flex-1 truncate font-medium text-sm"
-                                          title={folder.name}
-                                        >
-                                          {folder.name}
-                                        </span>
-                                      </div>
+                                    <div className="grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+                                      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground">
+                                        folder
+                                      </span>
+                                      <span
+                                        className="truncate font-medium text-sm"
+                                        title={folder.name}
+                                      >
+                                        {folder.name}
+                                      </span>
                                       <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
                                         {folderUpdatedLabel}
                                       </span>

--- a/apps/web/src/components/files/file-card-thumbnail.tsx
+++ b/apps/web/src/components/files/file-card-thumbnail.tsx
@@ -236,23 +236,18 @@ export function FileCard({
           <div className="pointer-events-none absolute inset-0 bg-black opacity-0 transition-opacity duration-300 group-hover:opacity-10" />
         ) : null}
       </div>
-      <div className="flex min-w-0 flex-col gap-2">
-        <div className="flex w-full min-w-0 max-w-full items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            {titleIcon ? (
-              titleIcon
-            ) : (
-              <span className="shrink-0 text-muted-foreground">
-                {getFileIcon(fileType)}
-              </span>
-            )}
-            <span
-              className="min-w-0 flex-1 truncate font-medium text-sm"
-              title={name}
-            >
-              {name}
+      <div className="flex w-full min-w-0 flex-col gap-2">
+        <div className="grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+          {titleIcon ? (
+            titleIcon
+          ) : (
+            <span className="shrink-0 text-muted-foreground">
+              {getFileIcon(fileType)}
             </span>
-          </div>
+          )}
+          <span className="truncate font-medium text-sm" title={name}>
+            {name}
+          </span>
           <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
             {timeAgo}
           </span>

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -29,6 +29,7 @@
     "abso-ai": "^0.0.9",
     "ai": "^7.0.2",
     "bullmq": "^5.70.4",
+    "defuddle": "^0.19.1",
     "drizzle-orm": "0.45.2",
     "firecrawl": "^4.30.0",
     "officeparser": "7.2.3",

--- a/packages/ingestion/src/ingestion/link.test.ts
+++ b/packages/ingestion/src/ingestion/link.test.ts
@@ -28,14 +28,32 @@ describe("link ingestion", () => {
     scrapeMock.mockReset();
   });
 
-  it("gets reader markdown and a full-page screenshot in one Firecrawl run", async () => {
+  it("cleans Firecrawl HTML with Defuddle and keeps the full-page screenshot", async () => {
     scrapeMock.mockResolvedValue({
-      markdown:
-        "## Introduction\n\nToday we're announcing Project Glasswing.\n\n**Mythos Preview** found critical vulnerabilities.",
+      html: `<!doctype html>
+        <html>
+          <head>
+            <title>Project Glasswing</title>
+            <meta name="description" content="Securing critical software for the AI era">
+            <link rel="icon" href="/favicon.ico">
+          </head>
+          <body>
+            <nav>Products Pricing Company</nav>
+            <main>
+              <article>
+                <h1>Project Glasswing</h1>
+                <h2>Introduction</h2>
+                <p>Today we're announcing Project Glasswing.</p>
+                <p><strong>Mythos Preview</strong> found critical vulnerabilities.</p>
+              </article>
+            </main>
+            <footer>Privacy Terms</footer>
+          </body>
+        </html>`,
       metadata: {
-        description: "Securing critical software for the AI era",
-        favicon: "https://anthropic.com/favicon.ico",
-        title: "Project Glasswing",
+        description: "Fallback description",
+        favicon: "https://anthropic.com/fallback.ico",
+        title: "Fallback title",
       },
       screenshot: "https://firecrawl.example/screenshots/glasswing.png",
       summary: "A new initiative for securing critical software.",
@@ -46,21 +64,23 @@ describe("link ingestion", () => {
     expect(preview.mode).toBe("firecrawl");
     expect(preview.provider).toBe("firecrawl");
     expect(preview.kind).toBe("article");
+    expect(preview.title).toBe("Project Glasswing");
     expect(preview.imageUrl).toBe(
       "https://firecrawl.example/screenshots/glasswing.png"
     );
-    expect(preview.readerMarkdown).toContain("Introduction");
+    expect(preview.readerMarkdown).toContain("## Introduction");
     expect(preview.readerMarkdown).toContain("**Mythos Preview**");
+    expect(preview.readerMarkdown).not.toContain("Products Pricing Company");
     expect(scrapeMock).toHaveBeenCalledTimes(1);
     expect(scrapeMock).toHaveBeenCalledWith(
       "https://anthropic.com/glasswing",
       expect.objectContaining({
         formats: expect.arrayContaining([
-          "markdown",
+          "html",
           "summary",
           expect.objectContaining({ fullPage: true, type: "screenshot" }),
         ]),
-        onlyMainContent: true,
+        onlyMainContent: false,
       })
     );
   });

--- a/packages/ingestion/src/ingestion/link.ts
+++ b/packages/ingestion/src/ingestion/link.ts
@@ -1,3 +1,4 @@
+import { Defuddle } from "defuddle/node";
 import { Firecrawl } from "firecrawl";
 import { z } from "zod";
 import { config } from "../config";
@@ -35,7 +36,7 @@ export interface LinkPreview {
 }
 
 const FirecrawlDocumentSchema = z.object({
-  markdown: z.string().optional(),
+  html: z.string().optional(),
   metadata: z
     .object({
       description: z.string().optional(),
@@ -92,7 +93,7 @@ const extractViaFirecrawl = async (url: string) => {
   const response = await getFirecrawlClient().scrape(url, {
     blockAds: true,
     formats: [
-      "markdown",
+      "html",
       "summary",
       {
         type: "screenshot",
@@ -101,24 +102,40 @@ const extractViaFirecrawl = async (url: string) => {
         viewport: { height: 900, width: 1440 },
       },
     ],
-    onlyMainContent: true,
+    onlyMainContent: false,
     removeBase64Images: true,
   });
   const parsed = FirecrawlDocumentSchema.parse(response);
-  const markdown = normalizeOptionalString(parsed.markdown);
+  const html = normalizeOptionalString(parsed.html);
+  if (!html) {
+    throw new Error(`Firecrawl returned empty HTML for ${url}`);
+  }
+
+  const defuddled = await Defuddle(html, url, {
+    markdown: true,
+    useAsync: false,
+  });
+  const markdown = normalizeOptionalString(defuddled.content);
   if (!markdown) {
-    throw new Error(`Firecrawl returned empty markdown for ${url}`);
+    throw new Error(`Defuddle returned empty Markdown for ${url}`);
   }
 
   return {
     description:
+      normalizeOptionalString(defuddled.description) ??
       normalizeOptionalString(parsed.summary) ??
       normalizeOptionalString(parsed.metadata?.description),
-    favicon: normalizeOptionalString(parsed.metadata?.favicon),
+    favicon:
+      normalizeOptionalString(defuddled.favicon) ??
+      normalizeOptionalString(parsed.metadata?.favicon),
     markdown,
-    pageImageUrl: normalizeOptionalString(parsed.metadata?.ogImage),
+    pageImageUrl:
+      normalizeOptionalString(defuddled.image) ??
+      normalizeOptionalString(parsed.metadata?.ogImage),
     screenshotUrl: normalizeOptionalString(parsed.screenshot),
-    title: normalizeOptionalString(parsed.metadata?.title),
+    title:
+      normalizeOptionalString(defuddled.title) ??
+      normalizeOptionalString(parsed.metadata?.title),
   };
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,9 @@ importers:
       bullmq:
         specifier: ^5.70.4
         version: 5.70.4
+      defuddle:
+        specifier: ^0.19.1
+        version: 0.19.1
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0(prisma@7.4.2(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
@@ -873,7 +876,7 @@ importers:
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       shadcn:
         specifier: ^4.1.1
-        version: 4.1.1(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
+        version: 4.1.1(@cfworker/json-schema@4.1.1)(@types/node@26.1.1)(typescript@5.9.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7743,6 +7746,10 @@ packages:
     resolution: {integrity: sha512-ZIouJe2TcVMZDTpU4G0UBA+kN101dBQ5fxCsamq/zgH4etbRZTd86fcWbYrnus28SFBpMyHWCbL23P1rkp4XUw==}
     hasBin: true
 
+  defuddle@0.19.1:
+    resolution: {integrity: sha512-7e2IVQYuNncMe9Ws8KkU/KHD8H1LFfFPmdTgRVuQNgJPOeQQSqZzAhacCyNAGwg44cM2vwuCW1cy9fmbdOZ+pA==}
+    hasBin: true
+
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
@@ -9547,6 +9554,9 @@ packages:
 
   mathml-to-latex@1.5.0:
     resolution: {integrity: sha512-rrWn0eEvcEcdMM4xfHcSGIy+i01DX9byOdXTLWg+w1iJ6O6ohP5UXY1dVzNUZLhzfl3EGcRekWLhY7JT5Omaew==}
+
+  mathml-to-latex@1.8.0:
+    resolution: {integrity: sha512-gQ0uK3zqB8HwlfaXJkEL5rgaZNbKUiBMmBP/B/W+b+t6KcseLSuYb1b0BjLgS9ZiQa24ePkqTX8/6FaQuDL7wQ==}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -11529,6 +11539,10 @@ packages:
 
   temml@0.13.2:
     resolution: {integrity: sha512-n8fDRSsLscq9nh9j6z+FgkCvFMT0IJm6GCgwfzh+7AHT3Sfb4jFTQlsA6hVcF2dYYr3b66oDBVES95RfoukyrA==}
+    engines: {node: '>=18.13.0'}
+
+  temml@0.13.3:
+    resolution: {integrity: sha512-GLNEdf5qBWux3adbOxFus4jlds8nCdEIkkKq99m/4GGTfqnsjlVlK/i371Ux7yYSg/WNmOyAkNT/GJlZoJ0v+w==}
     engines: {node: '>=18.13.0'}
 
   tesseract.js-core@7.0.0:
@@ -18513,7 +18527,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.3.5)(@vitest/coverage-v8@4.1.7)(happy-dom@20.10.2)(msw@2.12.14(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.7(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.7)(happy-dom@20.10.2)(msw@2.12.14(@types/node@25.4.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.4.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass@1.98.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -19644,6 +19658,17 @@ snapshots:
       linkedom: 0.18.12
       mathml-to-latex: 1.5.0
       temml: 0.13.2
+      turndown: 7.2.2
+    transitivePeerDependencies:
+      - canvas
+
+  defuddle@0.19.1:
+    dependencies:
+      commander: 12.1.0
+    optionalDependencies:
+      linkedom: 0.18.12
+      mathml-to-latex: 1.8.0
+      temml: 0.13.3
       turndown: 7.2.2
     transitivePeerDependencies:
       - canvas
@@ -21527,6 +21552,11 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mathml-to-latex@1.5.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+    optional: true
+
+  mathml-to-latex@1.8.0:
     dependencies:
       '@xmldom/xmldom': 0.8.13
     optional: true
@@ -23987,7 +24017,7 @@ snapshots:
       - supports-color
       - typescript
 
-  shadcn@4.1.1(@cfworker/json-schema@4.1.1)(typescript@5.9.3):
+  shadcn@4.1.1(@cfworker/json-schema@4.1.1)(@types/node@26.1.1)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -24417,6 +24447,9 @@ snapshots:
     optional: true
 
   temml@0.13.2:
+    optional: true
+
+  temml@0.13.3:
     optional: true
 
   tesseract.js-core@7.0.0: {}


### PR DESCRIPTION
## Summary
- keep file icons and timestamps fixed while truncating card titles
- preserve optimistic link cards by invalidating workspace read caches
- fetch HTML with Firecrawl and generate reader-friendly Markdown with Defuddle

## Validation
- pnpm --filter @avenire/web check-types
- pnpm --filter @avenire/backend check-types
- pnpm --filter @avenire/ingestion check-types
- pnpm --filter @avenire/ingestion test -- link.test.ts
- React Doctor: 97/100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Link imports now produce cleaner, more focused markdown content while preserving page metadata and screenshots.
  - Workspace file and link views refresh more reliably after link updates and new link files are created.

- **UI Improvements**
  - Improved file and folder card layouts with better title truncation and alignment.
  - Pending link imports now display a clearer “now” status indicator.
  - Imported names no longer gain an unwanted `.md` or `.mdx` suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->