### PR TITLE
feat: keep teaching progress out of workspace files

### DIFF
--- a/apps/web/src/lib/chat-tools/chat-tool-utility-runtime.test.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-utility-runtime.test.ts
@@ -7,6 +7,7 @@ const { loadSkillsMock, searchMock } = vi.hoisted(() => ({
 
 vi.mock("@avenire/ai/skills", () => ({
   AVAILABLE_STUDY_SKILLS: ["explain", "summarize"],
+  AVAILABLE_TEACHING_SKILLS: [],
   AVAILABLE_VISUAL_SKILLS: ["diagram", "chart"],
   loadSkills: loadSkillsMock,
 }));

--- a/apps/web/src/lib/chat-tools/chat-tool-utility-runtime.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-utility-runtime.ts
@@ -1,8 +1,14 @@
 import {
   AVAILABLE_STUDY_SKILLS,
+  AVAILABLE_TEACHING_SKILLS,
   AVAILABLE_VISUAL_SKILLS,
   loadSkills,
 } from "@avenire/ai/skills";
+import {
+  getTeachingArtifacts,
+  saveTeachingArtifact,
+  type TeachingArtifactKind,
+} from "@avenire/database";
 import { Firecrawl } from "firecrawl";
 import { z } from "zod";
 
@@ -47,6 +53,12 @@ type WebSearchInput = z.infer<
 >;
 type LoadSkillInput = z.infer<
   typeof import("@avenire/ai/tools").chatToolSchemas["load_skill"]["input"]
+>;
+type TeachingWorkspaceInput = z.infer<
+  typeof import("@avenire/ai/tools").chatToolSchemas["get_teaching_workspace"]["input"]
+>;
+type SaveTeachingArtifactInput = z.infer<
+  typeof import("@avenire/ai/tools").chatToolSchemas["save_teaching_artifact"]["input"]
 >;
 type VisualizeReadMeInput = z.infer<
   typeof import("@avenire/ai/tools").chatToolSchemas["visualize_read_me"]["input"]
@@ -131,7 +143,9 @@ export async function executeLoadSkill(input: LoadSkillInput) {
     new Set(
       input.skills.flatMap((skillName) => {
         const normalizedName = skillName.trim();
-        return AVAILABLE_STUDY_SKILLS.some((skill) => skill === normalizedName)
+        return [...AVAILABLE_STUDY_SKILLS, ...AVAILABLE_TEACHING_SKILLS].some(
+          (skill) => skill === normalizedName
+        )
           ? [normalizedName]
           : [];
       })
@@ -143,6 +157,34 @@ export async function executeLoadSkill(input: LoadSkillInput) {
   return {
     content: loadSkills(skills),
     skills,
+  };
+}
+
+export async function executeGetTeachingWorkspace(
+  ctx: { userId: string; workspaceId: string },
+  input: TeachingWorkspaceInput
+) {
+  return getTeachingArtifacts({
+    ...input,
+    kind: input.kind as TeachingArtifactKind | undefined,
+    userId: ctx.userId,
+    workspaceId: ctx.workspaceId,
+  });
+}
+
+export async function executeSaveTeachingArtifact(
+  ctx: { userId: string; workspaceId: string },
+  input: SaveTeachingArtifactInput
+) {
+  const artifact = await saveTeachingArtifact({
+    ...input,
+    kind: input.kind as TeachingArtifactKind,
+    userId: ctx.userId,
+    workspaceId: ctx.workspaceId,
+  });
+  return {
+    artifact,
+    summary: `Saved ${artifact.kind} "${artifact.title}" in the private teaching workspace.`,
   };
 }
 

--- a/apps/web/src/lib/chat-tools/chat-tool-utility-runtime.ts
+++ b/apps/web/src/lib/chat-tools/chat-tool-utility-runtime.ts
@@ -6,6 +6,7 @@ import {
 } from "@avenire/ai/skills";
 import {
   getTeachingArtifacts,
+  readTeachingArtifact,
   saveTeachingArtifact,
   type TeachingArtifactKind,
 } from "@avenire/database";
@@ -59,6 +60,9 @@ type TeachingWorkspaceInput = z.infer<
 >;
 type SaveTeachingArtifactInput = z.infer<
   typeof import("@avenire/ai/tools").chatToolSchemas["save_teaching_artifact"]["input"]
+>;
+type ReadTeachingArtifactInput = z.infer<
+  typeof import("@avenire/ai/tools").chatToolSchemas["read_teaching_artifact"]["input"]
 >;
 type VisualizeReadMeInput = z.infer<
   typeof import("@avenire/ai/tools").chatToolSchemas["visualize_read_me"]["input"]
@@ -170,6 +174,19 @@ export async function executeGetTeachingWorkspace(
     userId: ctx.userId,
     workspaceId: ctx.workspaceId,
   });
+}
+
+export async function executeReadTeachingArtifact(
+  ctx: { userId: string; workspaceId: string },
+  input: ReadTeachingArtifactInput
+) {
+  const artifact = await readTeachingArtifact({
+    ...input,
+    kind: input.kind as TeachingArtifactKind,
+    userId: ctx.userId,
+    workspaceId: ctx.workspaceId,
+  });
+  return { artifact };
 }
 
 export async function executeSaveTeachingArtifact(

--- a/apps/web/src/lib/chat-tools/index.ts
+++ b/apps/web/src/lib/chat-tools/index.ts
@@ -33,6 +33,7 @@ import {
 import {
   executeLoadSkill,
   executeGetTeachingWorkspace,
+  executeReadTeachingArtifact,
   executeSaveTeachingArtifact,
   executeShowWidgetWithOptions,
   executeVisualizeReadMe,
@@ -260,6 +261,13 @@ export function createChatTools(ctx: ChatToolContext): ToolSet {
       inputSchema: toolSchema(chatToolSchemas.get_teaching_workspace.input),
       outputSchema: toolSchema(chatToolSchemas.get_teaching_workspace.output),
       execute: async (input) => executeGetTeachingWorkspace(ctx, input),
+    }),
+    read_teaching_artifact: tool({
+      description:
+        "Read one full teaching artifact (mission, resource, note, reference, lesson, or learning-record) by kind and slug after get_teaching_workspace identifies it. Use for targeted content reads.",
+      inputSchema: toolSchema(chatToolSchemas.read_teaching_artifact.input),
+      outputSchema: toolSchema(chatToolSchemas.read_teaching_artifact.output),
+      execute: async (input) => executeReadTeachingArtifact(ctx, input),
     }),
     save_teaching_artifact: tool({
       description:

--- a/apps/web/src/lib/chat-tools/index.ts
+++ b/apps/web/src/lib/chat-tools/index.ts
@@ -32,6 +32,8 @@ import {
 } from "@/lib/chat-tools/chat-tool-study-runtime";
 import {
   executeLoadSkill,
+  executeGetTeachingWorkspace,
+  executeSaveTeachingArtifact,
   executeShowWidgetWithOptions,
   executeVisualizeReadMe,
   runWebSearch,
@@ -247,10 +249,24 @@ export function createChatTools(ctx: ChatToolContext): ToolSet {
     }),
     load_skill: tool({
       description:
-        "Load a study-guideline skill into context. Use this before acting on structured study tasks like explanations, summaries, notes, mindset cards, or quizzes.",
+        "Load a study or teaching skill into context before acting on a matching task.",
       inputSchema: toolSchema(chatToolSchemas.load_skill.input),
       outputSchema: toolSchema(chatToolSchemas.load_skill.output),
       execute: async (input) => executeLoadSkill(input),
+    }),
+    get_teaching_workspace: tool({
+      description:
+        "Read the private teaching workspace for this user and workspace. Use it before teaching, planning a learning path, or running a learning retrospective. This state is not a visible workspace file.",
+      inputSchema: toolSchema(chatToolSchemas.get_teaching_workspace.input),
+      outputSchema: toolSchema(chatToolSchemas.get_teaching_workspace.output),
+      execute: async (input) => executeGetTeachingWorkspace(ctx, input),
+    }),
+    save_teaching_artifact: tool({
+      description:
+        "Save mission, resource, note, reference, lesson, or learning-record content to the private teaching workspace. Use explicit complete content; do not create visible workspace files for teaching state.",
+      inputSchema: toolSchema(chatToolSchemas.save_teaching_artifact.input),
+      outputSchema: toolSchema(chatToolSchemas.save_teaching_artifact.output),
+      execute: async (input) => executeSaveTeachingArtifact(ctx, input),
     }),
     visualize_read_me: tool({
       description:

--- a/packages/ai/prompts/chat.ts
+++ b/packages/ai/prompts/chat.ts
@@ -49,7 +49,7 @@ export function APOLLO_PROMPT(
     `You are Avenire AI assistant${userName ? ` for ${userName}` : ""}.`,
     "Answer directly. Be concise, specific, and correct.",
     "When you write math, always use LaTeX delimiters in normal text: inline math with $...$ and display math with $$...$$ if needed. Never wrap math in ```latex fences.",
-    "Default to general knowledge; do not access workspace tools unless the user explicitly asks about their files/workspace or the request is too niche to answer without personal context.",
+    "Default to general knowledge; do not access workspace tools unless the user explicitly asks about their files/workspace, the request is too niche to answer without personal context, or the request is for teaching.",
     "If a niche request lacks context, ask one brief clarification. Search the workspace only when the user asks about it or confirms that personal context is needed.",
     "Use the avenire_agent tool for workspace retrieval (searching, reading, summarizing files) only when the above conditions apply.",
     "When workspace retrieval tools return citations or citationMarkdown, cite workspace-derived factual claims in your final answer.",

--- a/packages/ai/prompts/chat.ts
+++ b/packages/ai/prompts/chat.ts
@@ -47,10 +47,10 @@ export function APOLLO_PROMPT(
     : context;
   return [
     `You are Avenire AI assistant${userName ? ` for ${userName}` : ""}.`,
-    "Keep responses concise, correct, and helpful.",
+    "Answer directly. Be concise, specific, and correct.",
     "When you write math, always use LaTeX delimiters in normal text: inline math with $...$ and display math with $$...$$ if needed. Never wrap math in ```latex fences.",
     "Default to general knowledge; do not access workspace tools unless the user explicitly asks about their files/workspace or the request is too niche to answer without personal context.",
-    "If the topic is niche or lacks context, ask a brief clarification first; only explore the workspace if the user confirms or references their files.",
+    "If a niche request lacks context, ask one brief clarification. Search the workspace only when the user asks about it or confirms that personal context is needed.",
     "Use the avenire_agent tool for workspace retrieval (searching, reading, summarizing files) only when the above conditions apply.",
     "When workspace retrieval tools return citations or citationMarkdown, cite workspace-derived factual claims in your final answer.",
     "Use this exact citation format for workspace sources: [workspace/path.ext](workspace-file://<fileId>).",
@@ -92,10 +92,10 @@ export function APOLLO_PROMPT(
     "Use topic-scoped due-card checks when possible by passing the relevant subject, topic, and concept to get_due_cards.",
     "Only generate flashcards or quizzes when the user explicitly asks for them or provides study material for that purpose.",
     "When creating flashcards for a topic or misconception, prefer extending the existing deck for that same topic instead of creating a duplicate deck.",
-    "When a request clearly matches a study-guideline skill, call load_skill first to fetch the matching instructions into context before acting.",
-    "Study-oriented skills available through load_skill include `concept-explainer`, `summary-generator`, `study-notes-creator`, `flashcard-creator`, and `quiz-creator`.",
+    "When a request matches a skill, call load_skill before acting. Study skills include `concept-explainer`, `summary-generator`, `study-notes-creator`, `flashcard-creator`, and `quiz-creator`. Teaching skills include `teach`, `create-learning-path`, and `run-learning-retrospective`.",
+    "Teaching state is private application data. Before teaching, read `get_teaching_workspace`; save mission, resources, references, lessons, notes, and learning records with `save_teaching_artifact`. Do not create visible workspace files for teaching state.",
     'For widgets, use `type: "spec"` when the existing primitives clearly fit; use `type: "code"` for custom SVG/canvas, controls, animation, simulations, maps, or unsupported chart types. The schema path is optional: choose the mode from the artifact, not from response length.',
-    "When you decide to use show_widget, call the tool directly with the complete final `widget` payload. Do not write user-visible narration about building JSON, trying again, missing schema fields, empty code, tool formatting, or what you are about to send to the tool.",
+    "When using show_widget, call it directly with the complete final `widget` payload. Do not narrate tool payload construction or retries.",
     allowVisualizations
       ? "Use show_widget when a visual makes comparison, process, trend, or dense data easier to scan. Call visualize_read_me first with only the needed modules, then set `i_have_seen_read_me: true`. Route `diagram` to mostly-static SVG structures, `chart` to quantitative data, `interactive` to controls/steppers/calculators, `physics` to simulations, `mockup` to app-like UI, and `art` to non-analytical illustration. Prefer `spec` when the primitives clearly fit; use `code` for custom drawing or interaction. Lead with the key signal, add only relevant controls, and keep labels short. Use three.js only for real 3D."
       : "Do not use show_widget or visualize_read_me in this conversation. You may still use load_skill for study-guideline skills when helpful.",

--- a/packages/ai/skills/scripts/generator.ts
+++ b/packages/ai/skills/scripts/generator.ts
@@ -2,7 +2,10 @@ import { readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-type SkillSection = "study-guidelines" | "visual-guidelines";
+type SkillSection =
+  | "agent-guidelines"
+  | "study-guidelines"
+  | "visual-guidelines";
 
 type ParsedFrontmatter = {
   attributes: {
@@ -198,14 +201,19 @@ async function main() {
     .filter((entry) => entry.section === "study-guidelines")
     .map((entry) => entry.id)
     .sort();
+  const teachingSkillIds = entries
+    .filter((entry) => entry.section === "agent-guidelines")
+    .map((entry) => entry.id)
+    .sort();
   const lines: string[] = [];
 
   lines.push("// This file is generated. Do not edit by hand.");
   lines.push("// Run: bun packages/ai/skills/scripts/generator.ts");
   lines.push("");
-  lines.push(
-    'export type SkillSection = "study-guidelines" | "visual-guidelines";'
-  );
+  lines.push('export type SkillSection =');
+  lines.push('  | "agent-guidelines"');
+  lines.push('  | "study-guidelines"');
+  lines.push('  | "visual-guidelines";');
   lines.push("");
   lines.push("export type SkillDefinition = {");
   lines.push("  id: string;");
@@ -239,6 +247,10 @@ async function main() {
   lines.push("");
   lines.push(
     `export const AVAILABLE_STUDY_SKILLS = ${JSON.stringify(studySkillIds)} as const;`
+  );
+  lines.push("");
+  lines.push(
+    `export const AVAILABLE_TEACHING_SKILLS = ${JSON.stringify(teachingSkillIds)} as const;`
   );
   lines.push("");
   lines.push(

--- a/packages/ai/skills/sections/agent-guidelines/create-learning-path.md
+++ b/packages/ai/skills/sections/agent-guidelines/create-learning-path.md
@@ -1,0 +1,16 @@
+---
+name: create-learning-path
+description: Build a personalized learning roadmap with milestones and practice checkpoints.
+---
+
+# Create a learning path
+
+Read the private teaching workspace with `get_teaching_workspace` first. Save the resulting roadmap as a `reference` or `lesson` artifact, not as a visible workspace file.
+
+1. Assess the learner's baseline and target outcome.
+2. Sequence the smallest set of topics from fundamentals to applied practice.
+3. Define achievable milestones, practice tasks, feedback criteria, and time-boxed checkpoints.
+4. Include reflection in every phase and limit the resource list.
+5. End with a measurable next milestone.
+
+Completion means the roadmap names the target, order, practice, feedback, timing, and next checkpoint.

--- a/packages/ai/skills/sections/agent-guidelines/run-learning-retrospective.md
+++ b/packages/ai/skills/sections/agent-guidelines/run-learning-retrospective.md
@@ -1,0 +1,16 @@
+---
+name: run-learning-retrospective
+description: Review learning progress, find blockers, and adjust the next milestone.
+---
+
+# Run a learning retrospective
+
+Read the private teaching workspace with `get_teaching_workspace` first. Save the retrospective as a `learning-record` artifact, not as a visible workspace file.
+
+1. Compare completed work with the target outcomes.
+2. Identify recurring blockers and weak concepts from evidence, not impressions.
+3. Decide what to reinforce, what to defer, and why.
+4. Adjust pacing and practice tasks.
+5. Set one next milestone with a measurable checkpoint.
+
+Completion means the retrospective records progress, blockers, changes, and the next checkpoint.

--- a/packages/ai/skills/sections/agent-guidelines/teach.md
+++ b/packages/ai/skills/sections/agent-guidelines/teach.md
@@ -1,0 +1,25 @@
+---
+name: teach
+description: Teach a user a skill or concept across sessions with short lessons and practice. Use when the user asks to learn.
+---
+
+# Teach
+
+Use the private teaching workspace. Do not store teaching state in visible workspace files.
+
+## Before teaching
+
+1. Call `get_teaching_workspace` before teaching. Read the mission, learning records, notes, references, and resources it returns.
+2. If the mission is missing or unclear, ask why the learner wants this and what outcome they need. Do not invent a mission.
+3. Use trusted sources for factual content. Save sources as `resource` artifacts.
+
+## Lesson loop
+
+1. Teach only the knowledge needed for one narrowly scoped skill.
+2. Make the learner retrieve, apply, and receive feedback. Prefer a short interactive exercise.
+3. Save the lesson as a `lesson` artifact with a stable slug and complete HTML content.
+4. Save durable facts as `reference` artifacts and non-obvious progress as `learning-record` artifacts.
+5. Save mission changes only after the learner confirms them. Use the `mission` artifact for the current mission.
+6. End with a concrete next step and a way to ask follow-up questions.
+
+Keep lessons short enough to finish quickly. Favor storage strength over a smooth explanation: recall, spacing, and interleaving matter more than immediate fluency.

--- a/packages/ai/skills/sections/agent-guidelines/unslop.md
+++ b/packages/ai/skills/sections/agent-guidelines/unslop.md
@@ -1,0 +1,33 @@
+---
+name: unslop
+description: Rewrite plans and documentation in direct, specific language. Use when removing generic AI prose.
+---
+
+# Unslop
+
+Rewrite text so it sounds specific, direct, and human. Preserve meaning and the intended tone.
+
+## Process
+
+1. Scan for puffery, vague claims, filler, repetition, over-structured prose, and generic conclusions.
+2. Replace each with a concrete fact, instruction, decision, example, or number.
+3. Prefer active voice, plain words, varied sentence length, and sentence-case headings.
+4. Keep the author's point of view when it helps. Do not add enthusiasm or marketing language.
+5. Read the result once as a skeptical editor. Remove anything that could appear unchanged in another project's docs.
+
+## Remove
+
+- Puffery and promotion: "pivotal", "groundbreaking", "vibrant", "stunning", "must-visit", "testament".
+- Vague attribution: name the source or remove the claim.
+- Abstract metaphor jargon: "landscape", "flywheel", "north star", "bedrock", "scaffolding", "harness".
+- Fancy verbs: use "is", "has", "use", and "help" instead of "serves as", "boasts", "leverage", and "facilitate".
+- "Not just X, but Y", forced groups of three, synonym cycling, and false "from X to Y" ranges.
+- Filler such as "in order to", "it is important to note", and excessive hedging.
+- Chatbot phrases, sycophancy, decorative emojis, curly quotes, and em dashes.
+
+## Keep
+
+- One idea per sentence when a sentence becomes hard to parse.
+- A single source of truth for each rule.
+- Steps in execution order. End each step with a checkable completion condition.
+- Reference material behind a clear pointer when only one branch needs it.

--- a/packages/ai/skills/skills.ts
+++ b/packages/ai/skills/skills.ts
@@ -1,7 +1,10 @@
 // This file is generated. Do not edit by hand.
 // Run: bun packages/ai/skills/scripts/generator.ts
 
-export type SkillSection = "study-guidelines" | "visual-guidelines";
+export type SkillSection =
+  | "agent-guidelines"
+  | "study-guidelines"
+  | "visual-guidelines";
 
 export type SkillDefinition = {
   id: string;
@@ -793,6 +796,30 @@ Create a visual when it materially improves understanding or decision-making. Le
 - Are controls necessary, native, labeled, and keyboard accessible?
 - Does it fit from 736px to 320px without clipping or scrolling?
 - Does it remain correct during streaming, theme changes, resize, and reduced motion?
+`,
+  },
+  "create-learning-path": {
+    id: "create-learning-path",
+    title: "Create a learning path",
+    description: "Build a personalized learning roadmap with milestones and practice checkpoints.",
+    section: "agent-guidelines",
+    path: "sections/agent-guidelines/create-learning-path.md",
+    content: `---
+name: create-learning-path
+description: Build a personalized learning roadmap with milestones and practice checkpoints.
+---
+
+# Create a learning path
+
+Read the private teaching workspace with \`get_teaching_workspace\` first. Save the resulting roadmap as a \`reference\` or \`lesson\` artifact, not as a visible workspace file.
+
+1. Assess the learner's baseline and target outcome.
+2. Sequence the smallest set of topics from fundamentals to applied practice.
+3. Define achievable milestones, practice tasks, feedback criteria, and time-boxed checkpoints.
+4. Include reflection in every phase and limit the resource list.
+5. End with a measurable next milestone.
+
+Completion means the roadmap names the target, order, practice, feedback, timing, and next checkpoint.
 `,
   },
   "dashboard": {
@@ -2257,6 +2284,30 @@ C) [Explanation why correct and why others are wrong]
 - [ ] Formulas and equations are rendered inline with \`$...$\` or display with \`$$...$$\`, never fenced as \`\`\`latex
 `,
   },
+  "run-learning-retrospective": {
+    id: "run-learning-retrospective",
+    title: "Run a learning retrospective",
+    description: "Review learning progress, find blockers, and adjust the next milestone.",
+    section: "agent-guidelines",
+    path: "sections/agent-guidelines/run-learning-retrospective.md",
+    content: `---
+name: run-learning-retrospective
+description: Review learning progress, find blockers, and adjust the next milestone.
+---
+
+# Run a learning retrospective
+
+Read the private teaching workspace with \`get_teaching_workspace\` first. Save the retrospective as a \`learning-record\` artifact, not as a visible workspace file.
+
+1. Compare completed work with the target outcomes.
+2. Identify recurring blockers and weak concepts from evidence, not impressions.
+3. Decide what to reinforce, what to defer, and why.
+4. Adjust pacing and practice tasks.
+5. Set one next milestone with a measurable checkpoint.
+
+Completion means the retrospective records progress, blockers, changes, and the next checkpoint.
+`,
+  },
   "smartphone-layer-anatomy-example": {
     id: "smartphone-layer-anatomy-example",
     title: "Smartphone Layer Anatomy",
@@ -2911,6 +2962,39 @@ Before placing text in a box, check: does (text width + 2×padding) fit the cont
 **No rotated text**. \`<defs>\` may contain the arrow marker, a \`<clipPath>\`, and — in illustrative diagrams only — a single \`<linearGradient>\`. Nothing else: no filters, no patterns, no extra markers.
 `,
   },
+  "teach": {
+    id: "teach",
+    title: "Teach",
+    description: "Teach a user a skill or concept across sessions with short lessons and practice. Use when the user asks to learn.",
+    section: "agent-guidelines",
+    path: "sections/agent-guidelines/teach.md",
+    content: `---
+name: teach
+description: Teach a user a skill or concept across sessions with short lessons and practice. Use when the user asks to learn.
+---
+
+# Teach
+
+Use the private teaching workspace. Do not store teaching state in visible workspace files.
+
+## Before teaching
+
+1. Call \`get_teaching_workspace\` before teaching. Read the mission, learning records, notes, references, and resources it returns.
+2. If the mission is missing or unclear, ask why the learner wants this and what outcome they need. Do not invent a mission.
+3. Use trusted sources for factual content. Save sources as \`resource\` artifacts.
+
+## Lesson loop
+
+1. Teach only the knowledge needed for one narrowly scoped skill.
+2. Make the learner retrieve, apply, and receive feedback. Prefer a short interactive exercise.
+3. Save the lesson as a \`lesson\` artifact with a stable slug and complete HTML content.
+4. Save durable facts as \`reference\` artifacts and non-obvious progress as \`learning-record\` artifacts.
+5. Save mission changes only after the learner confirms them. Use the \`mission\` artifact for the current mission.
+6. End with a concrete next step and a way to ask follow-up questions.
+
+Keep lessons short enough to finish quickly. Favor storage strength over a smooth explanation: recall, spacing, and interleaving matter more than immediate fluency.
+`,
+  },
   "ui-components": {
     id: "ui-components",
     title: "Ui Components",
@@ -2948,6 +3032,47 @@ Use host utilities for geometry, surfaces, controls, typography, and interaction
 For concrete compositions, load the relevant examples from \`examples/\` only when needed. Do not copy incidental spacing or content from an example when the user’s artifact differs.
 `,
   },
+  "unslop": {
+    id: "unslop",
+    title: "Unslop",
+    description: "Rewrite plans and documentation in direct, specific language. Use when removing generic AI prose.",
+    section: "agent-guidelines",
+    path: "sections/agent-guidelines/unslop.md",
+    content: `---
+name: unslop
+description: Rewrite plans and documentation in direct, specific language. Use when removing generic AI prose.
+---
+
+# Unslop
+
+Rewrite text so it sounds specific, direct, and human. Preserve meaning and the intended tone.
+
+## Process
+
+1. Scan for puffery, vague claims, filler, repetition, over-structured prose, and generic conclusions.
+2. Replace each with a concrete fact, instruction, decision, example, or number.
+3. Prefer active voice, plain words, varied sentence length, and sentence-case headings.
+4. Keep the author's point of view when it helps. Do not add enthusiasm or marketing language.
+5. Read the result once as a skeptical editor. Remove anything that could appear unchanged in another project's docs.
+
+## Remove
+
+- Puffery and promotion: "pivotal", "groundbreaking", "vibrant", "stunning", "must-visit", "testament".
+- Vague attribution: name the source or remove the claim.
+- Abstract metaphor jargon: "landscape", "flywheel", "north star", "bedrock", "scaffolding", "harness".
+- Fancy verbs: use "is", "has", "use", and "help" instead of "serves as", "boasts", "leverage", and "facilitate".
+- "Not just X, but Y", forced groups of three, synonym cycling, and false "from X to Y" ranges.
+- Filler such as "in order to", "it is important to note", and excessive hedging.
+- Chatbot phrases, sycophancy, decorative emojis, curly quotes, and em dashes.
+
+## Keep
+
+- One idea per sentence when a sentence becomes hard to parse.
+- A single source of truth for each rule.
+- Steps in execution order. End each step with a checkable completion condition.
+- Reference material behind a clear pointer when only one branch needs it.
+`,
+  },
   "when-nothing-fits": {
     id: "when-nothing-fits",
     title: "When Nothing Fits",
@@ -2966,6 +3091,8 @@ Pick the closest use case below and adapt. When nothing fits cleanly:
 export type SkillId = keyof typeof SKILL_MAP;
 
 export const AVAILABLE_STUDY_SKILLS = ["auto-llm-example","concept-explainer","electricity-grid-flow-example","flashcard-creator","quiz-creator","smartphone-layer-anatomy-example","sn2-reaction-mechanism-example","study-notes-creator","summary-generator"] as const;
+
+export const AVAILABLE_TEACHING_SKILLS = ["create-learning-path","run-learning-retrospective","teach","unslop"] as const;
 
 export const AVAILABLE_VISUAL_SKILLS = ["art","chart","diagram","interactive","mockup","physics"] as const;
 

--- a/packages/ai/tools/index.ts
+++ b/packages/ai/tools/index.ts
@@ -1,6 +1,10 @@
 import { type InferUITools, tool } from "ai";
 import { z } from "zod";
-import { AVAILABLE_STUDY_SKILLS, AVAILABLE_VISUAL_SKILLS } from "../skills";
+import {
+  AVAILABLE_STUDY_SKILLS,
+  AVAILABLE_TEACHING_SKILLS,
+  AVAILABLE_VISUAL_SKILLS,
+} from "../skills";
 
 const sourceTypeSchema = z
   .enum(["pdf", "image", "video", "audio", "document", "markdown", "link"])
@@ -101,6 +105,25 @@ const misconceptionScopeSchema = z.object({
   limit: z.number().int().min(1).max(50).optional(),
   subject: z.string().min(1).optional(),
   topic: z.string().min(1).optional(),
+});
+
+const teachingArtifactKindSchema = z.enum([
+  "mission",
+  "resource",
+  "note",
+  "reference",
+  "lesson",
+  "learning-record",
+]);
+
+const teachingArtifactSchema = z.object({
+  content: z.string(),
+  createdAt: z.string(),
+  id: z.string(),
+  kind: teachingArtifactKindSchema,
+  slug: z.string(),
+  title: z.string(),
+  updatedAt: z.string(),
 });
 
 const widgetToneSchema = z
@@ -554,13 +577,40 @@ export const chatToolSchemas = {
     input: z.object({
       skills: z
         .array(
-          z.enum(AVAILABLE_STUDY_SKILLS as unknown as [string, ...string[]])
+          z.enum(
+            [...AVAILABLE_STUDY_SKILLS, ...AVAILABLE_TEACHING_SKILLS] as unknown as [
+              string,
+              ...string[],
+            ]
+          )
         )
         .min(1),
     }),
     output: z.object({
       content: z.string(),
       skills: z.array(z.string()),
+    }),
+  },
+  get_teaching_workspace: {
+    input: z.object({
+      kind: teachingArtifactKindSchema.optional(),
+      slug: z.string().min(1).optional(),
+    }),
+    output: z.object({
+      artifacts: z.array(teachingArtifactSchema),
+      mission: teachingArtifactSchema.nullable(),
+    }),
+  },
+  save_teaching_artifact: {
+    input: z.object({
+      content: z.string().min(1),
+      kind: teachingArtifactKindSchema,
+      slug: z.string().min(1),
+      title: z.string().min(1),
+    }),
+    output: z.object({
+      artifact: teachingArtifactSchema,
+      summary: z.string(),
     }),
   },
   visualize_read_me: {
@@ -762,6 +812,14 @@ export const chatTools = {
   load_skill: tool({
     inputSchema: chatToolSchemas.load_skill.input,
     outputSchema: chatToolSchemas.load_skill.output,
+  }),
+  get_teaching_workspace: tool({
+    inputSchema: chatToolSchemas.get_teaching_workspace.input,
+    outputSchema: chatToolSchemas.get_teaching_workspace.output,
+  }),
+  save_teaching_artifact: tool({
+    inputSchema: chatToolSchemas.save_teaching_artifact.input,
+    outputSchema: chatToolSchemas.save_teaching_artifact.output,
   }),
   visualize_read_me: tool({
     inputSchema: chatToolSchemas.visualize_read_me.input,

--- a/packages/ai/tools/index.ts
+++ b/packages/ai/tools/index.ts
@@ -116,8 +116,7 @@ const teachingArtifactKindSchema = z.enum([
   "learning-record",
 ]);
 
-const teachingArtifactSchema = z.object({
-  content: z.string(),
+const teachingArtifactMetadataSchema = z.object({
   createdAt: z.string(),
   id: z.string(),
   kind: teachingArtifactKindSchema,
@@ -125,6 +124,12 @@ const teachingArtifactSchema = z.object({
   title: z.string(),
   updatedAt: z.string(),
 });
+
+const teachingArtifactSchema = teachingArtifactMetadataSchema.extend({
+  content: z.string(),
+});
+
+const MAX_TEACHING_ARTIFACT_CONTENT_CHARS = 100_000;
 
 const widgetToneSchema = z
   .enum(["default", "muted", "info", "success", "warning", "danger"])
@@ -594,16 +599,25 @@ export const chatToolSchemas = {
   get_teaching_workspace: {
     input: z.object({
       kind: teachingArtifactKindSchema.optional(),
-      slug: z.string().min(1).optional(),
+      limit: z.number().int().min(1).max(50).optional(),
     }),
     output: z.object({
-      artifacts: z.array(teachingArtifactSchema),
-      mission: teachingArtifactSchema.nullable(),
+      artifacts: z.array(teachingArtifactMetadataSchema),
+      mission: teachingArtifactMetadataSchema.nullable(),
+    }),
+  },
+  read_teaching_artifact: {
+    input: z.object({
+      kind: teachingArtifactKindSchema,
+      slug: z.string().min(1),
+    }),
+    output: z.object({
+      artifact: teachingArtifactSchema,
     }),
   },
   save_teaching_artifact: {
     input: z.object({
-      content: z.string().min(1),
+      content: z.string().min(1).max(MAX_TEACHING_ARTIFACT_CONTENT_CHARS),
       kind: teachingArtifactKindSchema,
       slug: z.string().min(1),
       title: z.string().min(1),
@@ -816,6 +830,10 @@ export const chatTools = {
   get_teaching_workspace: tool({
     inputSchema: chatToolSchemas.get_teaching_workspace.input,
     outputSchema: chatToolSchemas.get_teaching_workspace.output,
+  }),
+  read_teaching_artifact: tool({
+    inputSchema: chatToolSchemas.read_teaching_artifact.input,
+    outputSchema: chatToolSchemas.read_teaching_artifact.output,
   }),
   save_teaching_artifact: tool({
     inputSchema: chatToolSchemas.save_teaching_artifact.input,

--- a/packages/database/drizzle/0024_teaching_artifacts.sql
+++ b/packages/database/drizzle/0024_teaching_artifacts.sql
@@ -7,7 +7,9 @@ CREATE TABLE IF NOT EXISTS "teaching_artifact" (
   "title" text NOT NULL,
   "content" text NOT NULL,
   "created_at" timestamptz DEFAULT now() NOT NULL,
-  "updated_at" timestamptz DEFAULT now() NOT NULL
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "teaching_artifact_kind_check" CHECK ("kind" IN ('mission', 'resource', 'note', 'reference', 'lesson', 'learning-record')),
+  CONSTRAINT "teaching_artifact_content_length_check" CHECK (length("content") <= 100000)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS "teaching_artifact_owner_slug_uidx"
   ON "teaching_artifact" ("user_id", "workspace_id", "kind", "slug");

--- a/packages/database/drizzle/0024_teaching_artifacts.sql
+++ b/packages/database/drizzle/0024_teaching_artifacts.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "teaching_artifact" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "workspace_id" uuid NOT NULL REFERENCES "workspace"("id") ON DELETE CASCADE,
+  "kind" text NOT NULL,
+  "slug" text NOT NULL,
+  "title" text NOT NULL,
+  "content" text NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "teaching_artifact_owner_slug_uidx"
+  ON "teaching_artifact" ("user_id", "workspace_id", "kind", "slug");
+CREATE INDEX IF NOT EXISTS "teaching_artifact_owner_kind_idx"
+  ON "teaching_artifact" ("user_id", "workspace_id", "kind", "updated_at");

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1783864800000,
       "tag": "0023_upload_session_idempotency",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1783864800001,
+      "tag": "0024_teaching_artifacts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -19,4 +19,5 @@ export * from "./session-summary-data";
 export * from "./schema";
 export * from "./sudo-data";
 export * from "./task-data";
+export * from "./teaching-data";
 export * from "./user-settings-data";

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import {
   boolean,
+  check,
   customType,
   index,
   integer,
@@ -211,6 +212,14 @@ export const teachingArtifact = pgTable(
       table.workspaceId,
       table.kind,
       table.updatedAt
+    ),
+    check(
+      "teaching_artifact_kind_check",
+      sql`${table.kind} in ('mission', 'resource', 'note', 'reference', 'lesson', 'learning-record')`
+    ),
+    check(
+      "teaching_artifact_content_length_check",
+      sql`length(${table.content}) <= 100000`
     ),
   ]
 );

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -178,6 +178,43 @@ export const sessionSummary = pgTable(
   ]
 );
 
+export const teachingArtifact = pgTable(
+  "teaching_artifact",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspace.id, { onDelete: "cascade" }),
+    kind: text("kind").notNull(),
+    slug: text("slug").notNull(),
+    title: text("title").notNull(),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("teaching_artifact_owner_slug_uidx").on(
+      table.userId,
+      table.workspaceId,
+      table.kind,
+      table.slug
+    ),
+    index("teaching_artifact_owner_kind_idx").on(
+      table.userId,
+      table.workspaceId,
+      table.kind,
+      table.updatedAt
+    ),
+  ]
+);
+
 export const fileFolder = pgTable(
   "file_folder",
   {

--- a/packages/database/src/teaching-data.ts
+++ b/packages/database/src/teaching-data.ts
@@ -1,0 +1,103 @@
+import { and, asc, desc, eq } from "drizzle-orm";
+import { db } from "./client";
+import { teachingArtifact } from "./schema";
+
+export const TEACHING_ARTIFACT_KINDS = [
+  "mission",
+  "resource",
+  "note",
+  "reference",
+  "lesson",
+  "learning-record",
+] as const;
+
+export type TeachingArtifactKind = (typeof TEACHING_ARTIFACT_KINDS)[number];
+
+export interface TeachingArtifactRecord {
+  content: string;
+  createdAt: string;
+  id: string;
+  kind: TeachingArtifactKind;
+  slug: string;
+  title: string;
+  updatedAt: string;
+}
+
+function toRecord(row: typeof teachingArtifact.$inferSelect): TeachingArtifactRecord {
+  return {
+    content: row.content,
+    createdAt: row.createdAt.toISOString(),
+    id: row.id,
+    kind: row.kind as TeachingArtifactKind,
+    slug: row.slug,
+    title: row.title,
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export async function getTeachingArtifacts(input: {
+  kind?: TeachingArtifactKind;
+  slug?: string;
+  userId: string;
+  workspaceId: string;
+}) {
+  const rows = await db
+    .select()
+    .from(teachingArtifact)
+    .where(
+      and(
+        eq(teachingArtifact.userId, input.userId),
+        eq(teachingArtifact.workspaceId, input.workspaceId),
+        input.kind ? eq(teachingArtifact.kind, input.kind) : undefined,
+        input.slug ? eq(teachingArtifact.slug, input.slug) : undefined
+      )
+    )
+    .orderBy(asc(teachingArtifact.kind), desc(teachingArtifact.updatedAt));
+
+  const artifacts = rows.map(toRecord);
+  return {
+    artifacts,
+    mission:
+      artifacts.find((artifact) => artifact.kind === "mission") ?? null,
+  };
+}
+
+export async function saveTeachingArtifact(input: {
+  content: string;
+  kind: TeachingArtifactKind;
+  slug: string;
+  title: string;
+  userId: string;
+  workspaceId: string;
+}) {
+  const [row] = await db
+    .insert(teachingArtifact)
+    .values({
+      content: input.content,
+      kind: input.kind,
+      slug: input.slug,
+      title: input.title,
+      userId: input.userId,
+      workspaceId: input.workspaceId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        teachingArtifact.userId,
+        teachingArtifact.workspaceId,
+        teachingArtifact.kind,
+        teachingArtifact.slug,
+      ],
+      set: {
+        content: input.content,
+        title: input.title,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  if (!row) {
+    throw new Error("Teaching artifact was not saved.");
+  }
+
+  return toRecord(row);
+}

--- a/packages/database/src/teaching-data.ts
+++ b/packages/database/src/teaching-data.ts
@@ -78,11 +78,23 @@ export async function getTeachingArtifacts(input: {
     .orderBy(asc(teachingArtifact.kind), desc(teachingArtifact.updatedAt))
     .limit(input.limit ?? 50);
 
+  const [missionRow] = await db
+    .select()
+    .from(teachingArtifact)
+    .where(
+      and(
+        eq(teachingArtifact.kind, "mission"),
+        eq(teachingArtifact.userId, input.userId),
+        eq(teachingArtifact.workspaceId, input.workspaceId)
+      )
+    )
+    .orderBy(desc(teachingArtifact.updatedAt))
+    .limit(1);
+
   const artifacts = rows.map(toMetadata);
   return {
     artifacts,
-    mission:
-      artifacts.find((artifact) => artifact.kind === "mission") ?? null,
+    mission: missionRow ? toMetadata(missionRow) : null,
   };
 }
 

--- a/packages/database/src/teaching-data.ts
+++ b/packages/database/src/teaching-data.ts
@@ -12,6 +12,11 @@ export const TEACHING_ARTIFACT_KINDS = [
 ] as const;
 
 export type TeachingArtifactKind = (typeof TEACHING_ARTIFACT_KINDS)[number];
+export const MAX_TEACHING_ARTIFACT_CONTENT_CHARS = 100_000;
+
+function isTeachingArtifactKind(value: string): value is TeachingArtifactKind {
+  return (TEACHING_ARTIFACT_KINDS as readonly string[]).includes(value);
+}
 
 export interface TeachingArtifactRecord {
   content: string;
@@ -23,21 +28,40 @@ export interface TeachingArtifactRecord {
   updatedAt: string;
 }
 
-function toRecord(row: typeof teachingArtifact.$inferSelect): TeachingArtifactRecord {
+export type TeachingArtifactMetadata = Omit<
+  TeachingArtifactRecord,
+  "content"
+>;
+
+function toMetadata(
+  row: typeof teachingArtifact.$inferSelect
+): TeachingArtifactMetadata {
+  if (!isTeachingArtifactKind(row.kind)) {
+    throw new Error(`Unsupported teaching artifact kind: ${row.kind}`);
+  }
+
   return {
-    content: row.content,
     createdAt: row.createdAt.toISOString(),
     id: row.id,
-    kind: row.kind as TeachingArtifactKind,
+    kind: row.kind,
     slug: row.slug,
     title: row.title,
     updatedAt: row.updatedAt.toISOString(),
   };
 }
 
+function toRecord(row: typeof teachingArtifact.$inferSelect): TeachingArtifactRecord {
+  const metadata = toMetadata(row);
+  return {
+    content: row.content,
+    ...metadata,
+  };
+}
+
+/** List bounded teaching metadata without loading lesson or reference bodies. */
 export async function getTeachingArtifacts(input: {
   kind?: TeachingArtifactKind;
-  slug?: string;
+  limit?: number;
   userId: string;
   workspaceId: string;
 }) {
@@ -49,12 +73,12 @@ export async function getTeachingArtifacts(input: {
         eq(teachingArtifact.userId, input.userId),
         eq(teachingArtifact.workspaceId, input.workspaceId),
         input.kind ? eq(teachingArtifact.kind, input.kind) : undefined,
-        input.slug ? eq(teachingArtifact.slug, input.slug) : undefined
       )
     )
-    .orderBy(asc(teachingArtifact.kind), desc(teachingArtifact.updatedAt));
+    .orderBy(asc(teachingArtifact.kind), desc(teachingArtifact.updatedAt))
+    .limit(input.limit ?? 50);
 
-  const artifacts = rows.map(toRecord);
+  const artifacts = rows.map(toMetadata);
   return {
     artifacts,
     mission:
@@ -62,6 +86,34 @@ export async function getTeachingArtifacts(input: {
   };
 }
 
+/** Read one teaching artifact body after metadata identifies the target. */
+export async function readTeachingArtifact(input: {
+  kind: TeachingArtifactKind;
+  slug: string;
+  userId: string;
+  workspaceId: string;
+}) {
+  const [row] = await db
+    .select()
+    .from(teachingArtifact)
+    .where(
+      and(
+        eq(teachingArtifact.kind, input.kind),
+        eq(teachingArtifact.slug, input.slug),
+        eq(teachingArtifact.userId, input.userId),
+        eq(teachingArtifact.workspaceId, input.workspaceId)
+      )
+    )
+    .limit(1);
+
+  if (!row) {
+    throw new Error("Teaching artifact not found.");
+  }
+
+  return toRecord(row);
+}
+
+/** Save a bounded teaching artifact using the caller's user and workspace scope. */
 export async function saveTeachingArtifact(input: {
   content: string;
   kind: TeachingArtifactKind;
@@ -70,6 +122,15 @@ export async function saveTeachingArtifact(input: {
   userId: string;
   workspaceId: string;
 }) {
+  if (!isTeachingArtifactKind(input.kind)) {
+    throw new Error(`Unsupported teaching artifact kind: ${input.kind}`);
+  }
+  if (input.content.length > MAX_TEACHING_ARTIFACT_CONTENT_CHARS) {
+    throw new Error(
+      `Teaching artifact content must be ${MAX_TEACHING_ARTIFACT_CONTENT_CHARS} characters or fewer.`
+    );
+  }
+
   const [row] = await db
     .insert(teachingArtifact)
     .values({


### PR DESCRIPTION
Teaching sessions were instructed to write MISSION.md, lessons, and learning records into the user's visible workspace. That exposes internal learning state as ordinary files and gives the model no reliable application-level store to read or update.

This change adds a private per-user, per-workspace teaching store backed by Postgres. Teaching skills now read and write mission, resource, note, reference, lesson, and learning-record artifacts through dedicated chat tools. It also registers the teaching skills and keeps the unslop skill available without adding writing-for-agents to Avenire.

Verification:
- bunx tsc --noEmit -p packages/database/tsconfig.json
- bunx tsc --noEmit -p packages/ai/tsconfig.json
- bun test packages/ai/prompts/chat.test.ts
- bun test packages/database/src/learning-taxonomy.test.ts
- git diff --check

The existing unrelated changes in packages/ui and docs/*.md remain unstaged and are not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added teaching support with personalized lessons, learning paths, retrospectives, and plan/document clarity improvements.
  * Added private teaching workspace access and teaching artifact creation, reading, and saving.
  * Teaching workspace results now show concise metadata, with full content available on demand.
* **Improvements**
  * Added limits and validation for artifact types, result counts, and content length.
  * Improved guidance for concise responses, interactive teaching, progress tracking, and measurable next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->